### PR TITLE
Suggestions for examples related to Arrow's integration docs

### DIFF
--- a/documentation/topics/arrow-integration.md
+++ b/documentation/topics/arrow-integration.md
@@ -91,9 +91,12 @@ println(message)
 
 ## Bind to Raise computation
 
-When working with Arrow's functional programming paradigms, the bind function is crucial in handling validations seamlessly, especially when dealing with multiple Either types. This is particularly useful when you're already inside a Raise computation.
+When working with Arrow's functional programming paradigms, the bind function is crucial in handling validations
+seamlessly, especially when dealing with multiple `Either` types. This is particularly useful when you're already inside
+a Raise computation.
 
 Let's consider an example where we have multiple data classes to validate:
+
 ```kotlin
 @Validate
 data class Book(val title: String)
@@ -110,43 +113,41 @@ val validateAuthor = Validator<Author> {
 }
 ```
 
-In a typical scenario, you might want to validate a Book and an Author within the same context. Without bind, you would convert each validation result to an Either and handle them separately, which can be cumbersome:
+In a typical scenario, you might want to validate a `Book` and an `Author` within the same context. Without bind, you
+would convert each validation result to an `Either` and handle them separately, which can be cumbersome:
 
 ```kotlin
-// Validate the book and convert the result to an Either
-val bookResult: Either<NonEmptySet<ConstraintViolation>, Book> = validateBook(Book("The Lord of the Rings")).toEither()
-
-// Validate the author and convert the result to an Either
-val authorResult: Either<NonEmptySet<ConstraintViolation>, Author> = validateAuthor(Author("J. R. R. Tolkien")).toEither()
+// Validate the data and convert the results to Either
+val bookResult = validateBook(Book("The Lord of the Rings")).toEither()
+val authorResult = validateAuthor(Author("J.R.R. Tolkien")).toEither()
 
 // Handle the validation results separately
 val book = when (bookResult) {
-    is Either.Left -> throw ValidationException(bookResult.value) //handle error
+    is Either.Left -> throw IllegalArgumentException("Invalid book")
     is Either.Right -> bookResult.value
 }
-
 val author = when (authorResult) {
-    is Either.Left -> throw ValidationException(authorResult.value) //handle error
+    is Either.Left -> throw IllegalArgumentException("Invalid author")
     is Either.Right -> authorResult.value
 }
 
-// Further computation with book and author
-// Example:
-println("Validated Book: $book, Validated Author: $author")
+// Further computation with the validated data
+println("Validated book: $book")
+println("Validated author: $author")
 ```
 
-However, using `bind` allows you to compute over the happy path by automatically handling errors and focusing on successful outcomes. When a validation fails, `bind` short-circuits the computation, eliminating the need for explicit error checking and handling within the `either` block. 
+However, using `bind` allows you to compute over the happy path by automatically handling errors and focusing on
+successful outcomes. When a validation fails, `bind` short-circuits the computation, eliminating the need for explicit
+error checking and handling within the `either` block.
 
 ```kotlin
 either {
-    // Directly bind the validation result for Book
+    // Directly bind the validation results
     val book = bind(validateBook(Book("The Lord of the Rings")))
+    val author = bind(validateAuthor(Author("J.R.R. Tolkien")))
 
-    // Directly bind the validation result for Author
-    val author = bind(validateAuthor(Author("J. R. R. Tolkien")))
-
-    // Further computation with validated book and author
-    // Example:
-    println("Validated Book: $book, Validated Author: $author")
+    // Further computation with the validated data
+    println("Validated book: $book")
+    println("Validated author: $author")
 }
 ```

--- a/integrations/arrow/src/jvmMain/kotlin/dev/nesk/akkurate/arrow/Arrow.kt
+++ b/integrations/arrow/src/jvmMain/kotlin/dev/nesk/akkurate/arrow/Arrow.kt
@@ -42,7 +42,7 @@ private fun ConstraintViolationSet.toNonEmptySet(): NonEmptySet<ConstraintViolat
  *     )
  * ```
  *
- * The string `"  The Lord of the Rings  "` returns `"The Lord of the Rings"` because the validation was successful and went through the `ifRight` block:
+ * A non-blank string is trimmed because the validation was successful and went through the `ifRight` block:
  * ```
  * normalizeBookName("  The Lord of the Rings  ") // Returns: "The Lord of the Rings"
  * ```
@@ -63,21 +63,24 @@ public fun <T> ValidationResult<T>.toEither(): Either<NonEmptySet<ConstraintViol
  * You can bind the result of the validation to a `Raise` computation:
  * ```
  * val validateBookName = Validator<String> { isNotBlank() }
+ * val validateAuthorName = Validator<String> { isNotBlank() }
  *
- * fun normalizeBookName(bookName: String) = either {
- *     val validatedBookName = bind(validateBookName(bookName))
- *     validatedBookName.trim()
+ * fun combineBookAndAuthor(bookName: String, authorName: String) = either {
+ *     val book = bind(validateBookName(bookName))
+ *     val author = bind(validateAuthorName(authorName))
+ *     "${book.trim()} by ${author.trim()}"
  * }
  * ```
  *
- * The string `"  The Lord of the Rings  "` returns [Either.Right] of `"The Lord of the Rings"` because the validation was successful and the [either] block could complete:
+ * Non-blank strings returns [Either.Right] because the validation was successful and the [either] block could complete:
  * ```
- * normalizeBookName("  The Lord of the Rings  ") // Returns: Either.Right(value = "The Lord of the Rings")
+ * combineBookAndAuthor("  The Lord of the Rings  ", "  J. R. R. Tolkien  ")
+ * // Returns: Either.Right(value = "The Lord of the Rings by J. R. R. Tolkien")
  * ```
  *
- * Whereas, a blank string fails the validation and interrupts the [either] block, returning a [Either.Left] of constraint violations:
+ * Whereas, a single blank string fails the validation and interrupts the [either] block, returning a [Either.Left] of constraint violations:
  * ```
- * normalizeBookName("  ") // Returns: Either.Left<NonEmptySet<ConstraintViolation>>
+ * normalizeBookName("  ", "  J. R. R. Tolkien  ") // Returns: Either.Left<NonEmptySet<ConstraintViolation>>
  * ```
  *
  * @return The validated value on successful result.


### PR DESCRIPTION
This PR updates the Arrow integration documentation, focusing on demonstrating multiple bind operations. The aim is to show how Akkurate handles validations involving more than one operation. 

The previous example with a single `bind` not consuming its result is usually considered an antipattern. In general, binding is only helpful inside an `either` block if there is more than one value to bind, and the second and further operations are somehow dependent on the results of previous operations.

Here, we assume that for some reason, you should not attempt to validate an `author` unless you have previously validated a `book`—still not the best example. The examples can be improved to show an actual use case of dependent monadic operations. Also, the examples may be expanded to include `Raise` vs. using `either` blocks and the use of context-receivers.
