### PR TITLE
Use version catalog for storing dependencies

### DIFF
--- a/akkurate-arrow/build.gradle.kts
+++ b/akkurate-arrow/build.gradle.kts
@@ -21,5 +21,10 @@ kotlin {
                 api(libs.arrow.core)
             }
         }
+        commonTest {
+            dependencies {
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
     }
 }

--- a/akkurate-core/build.gradle.kts
+++ b/akkurate-core/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(project(":akkurate-test"))
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/akkurate-core/build.gradle.kts
+++ b/akkurate-core/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     id("akkurate.kmp-library-conventions")
-    id("com.google.devtools.ksp") version "2.0.20-1.0.24"
+    id("com.google.devtools.ksp")
     id("org.jetbrains.dokka")
 }
 

--- a/akkurate-kotlinx-datetime/build.gradle.kts
+++ b/akkurate-kotlinx-datetime/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
 
         commonTest.dependencies {
             implementation(project(":akkurate-test"))
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/akkurate-ksp-plugin/build.gradle.kts
+++ b/akkurate-ksp-plugin/build.gradle.kts
@@ -4,25 +4,16 @@ plugins {
     id("akkurate.publishing-conventions")
     kotlin("jvm")
     id("org.jetbrains.dokka")
+    id("com.karumi.kotlin-snapshot")
 }
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath("com.karumi.kotlinsnapshot:plugin:2.3.0")
-    }
-}
-apply(plugin = "com.karumi.kotlin-snapshot")
 
 dependencies {
-    implementation("com.squareup:kotlinpoet:1.14.2")
-    implementation("com.squareup:kotlinpoet-ksp:1.14.2")
-    implementation("com.google.devtools.ksp:symbol-processing-api:1.9.10-1.0.13")
+    implementation(libs.kotlinpoet.core)
+    implementation(libs.kotlinpoet.ksp)
+    implementation(libs.kotlin.symbolProcessing.api)
 
     testImplementation(kotlin("test"))
-    testImplementation("com.github.tschuchortdev:kotlin-compile-testing-ksp:1.5.0")
+    testImplementation(libs.kotlinCompileTesting.ksp)
 }
 
 kotlin {

--- a/akkurate-ktor-client/build.gradle.kts
+++ b/akkurate-ktor-client/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
             implementation(libs.ktor.server.test)
             implementation(libs.ktor.client.contentNegotiation)
             implementation(libs.ktor.serialization.json)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/akkurate-ktor-client/build.gradle.kts
+++ b/akkurate-ktor-client/build.gradle.kts
@@ -4,7 +4,7 @@ import dev.nesk.akkurate.gradle.configureTargets
 plugins {
     id("akkurate.kmp-library-conventions")
     id("org.jetbrains.dokka")
-    alias(libs.plugins.kotlinx.serialization)
+    kotlin("plugin.serialization")
 }
 
 kotlin {

--- a/akkurate-ktor-server/build.gradle.kts
+++ b/akkurate-ktor-server/build.gradle.kts
@@ -4,7 +4,7 @@ import dev.nesk.akkurate.gradle.configureTargets
 plugins {
     id("akkurate.kmp-library-conventions")
     id("org.jetbrains.dokka")
-    alias(libs.plugins.kotlinx.serialization)
+    kotlin("plugin.serialization")
 }
 
 kotlin {

--- a/akkurate-ktor-server/build.gradle.kts
+++ b/akkurate-ktor-server/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
             implementation(libs.ktor.server.test)
             implementation(libs.ktor.server.contentNegotiation)
             implementation(libs.ktor.serialization.json)
+            implementation(libs.kotlinx.coroutines.test)
         }
         jvmTest.dependencies {
             implementation(libs.mockk)

--- a/akkurate-test/build.gradle.kts
+++ b/akkurate-test/build.gradle.kts
@@ -14,5 +14,10 @@ kotlin {
                 api(project(":akkurate-core"))
             }
         }
+        commonTest {
+            dependencies {
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,11 @@ repositories {
     mavenCentral()
 }
 
+/*
+ * Configure default gradle wrapper task to validate currently used gradle wrapper version against value set in versions
+ * catalog. When value differs task will automatically update wrapper configuration file with version from catalog.
+ * After this gradle wrapper binary will be updated before next task execution.
+*/
 tasks.named<Wrapper>("wrapper") {
     gradleVersion = libs.versions.gradle.wrapper.get()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,11 @@
 plugins {
-    id("org.jetbrains.dokka") version "1.9.0"
+    id("org.jetbrains.dokka")
 }
 
 repositories {
     mavenCentral()
+}
+
+tasks.named<Wrapper>("wrapper") {
+    gradleVersion = libs.versions.gradle.wrapper.get()
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,12 @@ repositories {
 }
 
 dependencies {
-    implementation("com.adarshr:gradle-test-logger-plugin:3.2.0")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.20")
-    implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.17.0")
+    implementation(libs.kotlin.plugin)
+    implementation(libs.kotlin.symbolProcessing.plugin)
+    implementation(libs.kotlinx.serialization.plugin)
+    implementation(libs.kotlinSnapshot.plugin)
+    implementation(libs.dokka.plugin)
+    implementation(libs.ktor.plugin)
+    implementation(libs.testLogger.plugin)
+    implementation(libs.kotlinx.binaryValidator.plugin)
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,1 +1,9 @@
 rootProject.name = "akkurate-conventions"
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/akkurate.kmp-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/akkurate.kmp-library-conventions.gradle.kts
@@ -22,7 +22,6 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0-RC.2")
             }
         }
     }

--- a/examples/ktor-server/build.gradle.kts
+++ b/examples/ktor-server/build.gradle.kts
@@ -1,15 +1,9 @@
-val ktor_version: String by project
-val kotlin_version: String by project
-val logback_version: String by project
-val exposed_version: String by project
-val h2_version: String by project
-
 plugins {
     id("akkurate.base-conventions")
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.5"
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.10"
-    id("com.google.devtools.ksp") version "2.0.20-1.0.24"
+    id("io.ktor.plugin")
+    kotlin("plugin.serialization")
+    id("com.google.devtools.ksp")
 }
 
 application {
@@ -20,24 +14,24 @@ application {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation-jvm:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-host-common-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-status-pages-jvm:$ktor_version")
-    implementation("org.jetbrains.exposed:exposed-core:$exposed_version")
-    implementation("org.jetbrains.exposed:exposed-jdbc:$exposed_version")
-    implementation("com.h2database:h2:$h2_version")
-    implementation("io.ktor:ktor-server-netty-jvm:$ktor_version")
-    implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-tests-jvm:$ktor_version")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.contentNegotiation)
+    implementation(libs.ktor.serialization.json)
+    implementation(libs.ktor.server.hostCommon)
+    implementation(libs.ktor.server.statusPages)
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.jdbc)
+    implementation(libs.h2)
+    implementation(libs.ktor.server.netty)
+    implementation(libs.logback)
+    testImplementation(libs.ktor.server.test)
+    testImplementation(libs.kotlin.test.junit)
 
     implementation(project(":akkurate-core"))
     implementation(project(":akkurate-ksp-plugin"))
     implementation(project(":akkurate-ktor-server"))
     ksp(project(":akkurate-ksp-plugin"))
-    implementation("io.ktor:ktor-server-request-validation:$ktor_version")
+    implementation(libs.ktor.server.requestValidation)
 }
 
 kotlin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,2 @@
 org.gradle.jvmargs=-Xmx4g
 kotlin.code.style=official
-kotlin_version=1.9.10
-ktor_version=3.0.1
-logback_version=1.4.14
-exposed_version=0.56.0
-h2_version=2.3.232

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 # https://gradle.org/releases/
+# To actually update gradle wrapper binary after updating this value call wrapper task ("gradlew wrapper") and any
+# other task aftewards.
 gradle-wrapper = "8.1.1"
 # https://kotlinlang.org/docs/releases.html
 kotlin-language = "2.0.20"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,76 @@
+[versions]
+# https://gradle.org/releases/
+gradle-wrapper = "8.1.1"
+# https://kotlinlang.org/docs/releases.html
+kotlin-language = "2.0.20"
+# https://github.com/google/ksp/releases
+kotlin-symbolProcessing = "2.0.20-1.0.24"
+# https://github.com/Kotlin/kotlinx.coroutines/releases
+kotlinx-coroutines = "1.9.0"
+# https://github.com/Kotlin/kotlinx-datetime/releases
+kotlinx-datetime = "0.6.1"
+# https://github.com/Kotlin/kotlinx.serialization/releases
+kotlinx-serialization = "1.7.3"
+# https://github.com/Kotlin/binary-compatibility-validator
+kotlinx-binaryValidator = "0.17.0"
+# https://github.com/ktorio/ktor/releases
+ktor = "3.0.0"
+# https://logback.qos.ch/news.html
+logback = "1.4.14"
+# https://github.com/JetBrains/Exposed/releases
+exposed = "0.56.0"
+# https://github.com/h2database/h2database/releases
+h2 = "2.3.232"
+# https://github.com/arrow-kt/arrow/releases
+arrow = "1.2.0"
+# https://github.com/Kotlin/dokka/releases
+dokka = "1.9.0"
+# https://square.github.io/kotlinpoet/changelog/
+kotlinpoet = "1.14.2"
+# https://github.com/tschuchortdev/kotlin-compile-testing/releases
+kotlinCompileTesting = "1.5.0"
+# https://github.com/pedrovgs/KotlinSnapshot/releases
+kotlinSnapshot = "2.3.0"
+# https://github.com/radarsh/gradle-test-logger-plugin/releases
+testLogger = "3.2.0"
+# https://github.com/mockk/mockk/releases
+mockk = "1.13.13"
+
+[libraries]
+kotlin-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin-language" }
+kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin-language" }
+kotlin-symbolProcessing-api = { group = "com.google.devtools.ksp", name = "symbol-processing-api", version.ref = "kotlin-symbolProcessing" }
+kotlin-symbolProcessing-plugin = { group = "com.google.devtools.ksp", name = "symbol-processing-gradle-plugin", version.ref = "kotlin-symbolProcessing" }
+
+kotlinx-serialization-plugin = { group = "org.jetbrains.kotlin.plugin.serialization", name = "org.jetbrains.kotlin.plugin.serialization.gradle.plugin", version.ref = "kotlin-language" }
+kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kotlinx-binaryValidator-plugin = { group = "org.jetbrains.kotlinx.binary-compatibility-validator", name = "org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version.ref = "kotlinx-binaryValidator" }
+
+kotlinpoet-core = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotlinpoet" }
+kotlinpoet-ksp = { group = "com.squareup", name = "kotlinpoet-ksp", version.ref = "kotlinpoet" }
+
+arrow-core = { group = "io.arrow-kt", name = "arrow-core", version.ref = "arrow" }
+
+ktor-plugin = { group = "io.ktor.plugin", name = "io.ktor.plugin.gradle.plugin", version.ref = "ktor" }
+ktor-serialization-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-server-core = { group = "io.ktor", name = "ktor-server-core", version.ref = "ktor" }
+ktor-server-netty = { group = "io.ktor", name = "ktor-server-netty", version.ref = "ktor" }
+ktor-server-contentNegotiation = { group = "io.ktor", name = "ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-hostCommon = { group = "io.ktor", name = "ktor-server-host-common", version.ref = "ktor" }
+ktor-server-statusPages = { group = "io.ktor", name = "ktor-server-status-pages", version.ref = "ktor" }
+ktor-server-requestValidation = { group = "io.ktor", name = "ktor-server-request-validation", version.ref = "ktor" }
+ktor-server-test = { group = "io.ktor", name = "ktor-server-test-host", version.ref = "ktor" }
+ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktor-client-contentNegotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+
+kotlinCompileTesting-ksp = { group = "com.github.tschuchortdev", name = "kotlin-compile-testing-ksp", version.ref = "kotlinCompileTesting" }
+kotlinSnapshot-plugin = { group = "com.karumi.kotlinsnapshot", name = "plugin", version.ref = "kotlinSnapshot" }
+dokka-plugin = { group = "org.jetbrains.dokka", name = "dokka-gradle-plugin", version.ref = "dokka" }
+exposed-core = { group = "org.jetbrains.exposed", name = "exposed-core", version.ref = "exposed" }
+exposed-jdbc = { group = "org.jetbrains.exposed", name = "exposed-jdbc", version.ref = "exposed" }
+h2 = { group = "com.h2database", name = "h2", version.ref = "h2" }
+logback = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback" }
+testLogger-plugin = { group = "com.adarshr", name = "gradle-test-logger-plugin", version.ref = "testLogger" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,26 +16,3 @@ include(
     "akkurate-ktor-client",
     "examples:ktor-server",
 )
-
-dependencyResolutionManagement {
-    versionCatalogs {
-        create("libs") {
-            version("ktor", "3.0.0")
-            version("kotlinx-serialization", "1.7.3")
-
-            plugin("kotlinx-serialization", "org.jetbrains.kotlin.plugin.serialization").version("2.0.20")
-
-            library("arrow-core", "io.arrow-kt:arrow-core:1.2.0")
-            library("kotlinx-datetime", "org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
-            library("kotlinx-serialization-core", "org.jetbrains.kotlinx", "kotlinx-serialization-core").versionRef("kotlinx-serialization")
-            library("kotlinx-serialization-json", "org.jetbrains.kotlinx", "kotlinx-serialization-json").versionRef("kotlinx-serialization")
-            library("ktor-client-contentNegotiation", "io.ktor", "ktor-client-content-negotiation").versionRef("ktor")
-            library("ktor-client-core", "io.ktor", "ktor-client-core").versionRef("ktor")
-            library("ktor-serialization-json", "io.ktor", "ktor-serialization-kotlinx-json").versionRef("ktor")
-            library("ktor-server-contentNegotiation", "io.ktor", "ktor-server-content-negotiation").versionRef("ktor")
-            library("ktor-server-requestValidation", "io.ktor", "ktor-server-request-validation").versionRef("ktor")
-            library("ktor-server-test", "io.ktor", "ktor-server-test-host").versionRef("ktor")
-            library("mockk", "io.mockk:mockk:1.13.13")
-        }
-    }
-}


### PR DESCRIPTION
Minified version of https://github.com/nesk/akkurate/pull/50 with only `libs.versions.toml` support