### PR TITLE
feat: Support custom metadata property

### DIFF
--- a/akkurate-arrow/src/commonMain/kotlin/dev/nesk/akkurate/arrow/Arrow.kt
+++ b/akkurate-arrow/src/commonMain/kotlin/dev/nesk/akkurate/arrow/Arrow.kt
@@ -23,8 +23,10 @@ import arrow.core.raise.either
 import dev.nesk.akkurate.ValidationResult
 import dev.nesk.akkurate.constraints.ConstraintViolation
 import dev.nesk.akkurate.constraints.ConstraintViolationSet
+import dev.nesk.akkurate.constraints.GenericConstraintViolation
+import dev.nesk.akkurate.constraints.GenericConstraintViolationSet
 
-private fun ConstraintViolationSet.toNonEmptySet(): NonEmptySet<ConstraintViolation> =
+private fun <E> GenericConstraintViolationSet<E>.toNonEmptySet(): NonEmptySet<GenericConstraintViolation<E>> =
     nonEmptySetOf(this.first(), *this.drop(1).toTypedArray())
 
 /**
@@ -52,7 +54,7 @@ private fun ConstraintViolationSet.toNonEmptySet(): NonEmptySet<ConstraintViolat
  * normalizeBookName("  ") // Returns: "<error: Must not be blank>"
  * ```
  */
-public fun <T> ValidationResult<T>.toEither(): Either<NonEmptySet<ConstraintViolation>, T> = when (this) {
+public fun <E, T> ValidationResult<E, T>.toEither(): Either<NonEmptySet<GenericConstraintViolation<E>>, T> = when (this) {
     is ValidationResult.Failure -> violations.toNonEmptySet().left()
     is ValidationResult.Success -> value.right()
 }
@@ -85,7 +87,7 @@ public fun <T> ValidationResult<T>.toEither(): Either<NonEmptySet<ConstraintViol
  *
  * @return The validated value on successful result.
  */
-public fun <T> Raise<NonEmptySet<ConstraintViolation>>.bind(validationResult: ValidationResult<T>): T = when (validationResult) {
+public fun <E, T> Raise<NonEmptySet<GenericConstraintViolation<E>>>.bind(validationResult: ValidationResult<E, T>): T = when (validationResult) {
     is ValidationResult.Failure -> raise(validationResult.violations.toNonEmptySet())
     is ValidationResult.Success -> validationResult.value
 }

--- a/akkurate-arrow/src/commonTest/kotlin/dev/nesk/akkurate/arrow/ArrowKtTest.kt
+++ b/akkurate-arrow/src/commonTest/kotlin/dev/nesk/akkurate/arrow/ArrowKtTest.kt
@@ -24,6 +24,7 @@ import dev.nesk.akkurate.ValidationResult
 import dev.nesk.akkurate.Validator
 import dev.nesk.akkurate.constraints.ConstraintViolation
 import dev.nesk.akkurate.constraints.builders.isIdenticalTo
+import dev.nesk.akkurate.validatables.DefaultMetadataType
 import kotlin.test.Test
 import kotlin.test.assertIs
 import kotlin.test.assertSame
@@ -59,7 +60,7 @@ class ArrowKtTest {
         val validationResult = validate(SomeSealedClass.Invalid)
         val validationEither = validationResult.toEither()
 
-        assertIs<ValidationResult.Failure>(validationResult)
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(validationResult)
         assertIs<Either.Left<NonEmptySet<ConstraintViolation>>>(validationEither, "The `Either` instance is a `Left` type")
         assertSame(
             validationResult.violations.single(),
@@ -87,7 +88,7 @@ class ArrowKtTest {
         val validationResult = validate(SomeSealedClass.Invalid)
         val validationEither = either { bind(validationResult) }
 
-        assertIs<ValidationResult.Failure>(validationResult)
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(validationResult)
         assertIs<Either.Left<NonEmptySet<ConstraintViolation>>>(validationEither, "The `Either` instance is a `Left` type")
         assertSame(
             validationResult.violations.single(),

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/AkkurateScratch.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/AkkurateScratch.kt
@@ -17,6 +17,7 @@
 
 package dev.nesk.akkurate
 
+import dev.nesk.akkurate.validatables.DefaultMetadataType
 import dev.nesk.akkurate.validatables.Validatable
 
 /**
@@ -62,13 +63,13 @@ internal class AkkurateScratch {
         public fun <ValueType> Validator(
             configuration: Configuration = Configuration(),
             block: Validatable<ValueType>.() -> Unit,
-        ): Validator.Runner<ValueType> = ValidatorWrapper(dev.nesk.akkurate.Validator(configuration, block))
+        ): Validator.Runner<ValueType, DefaultMetadataType> = ValidatorWrapper(dev.nesk.akkurate.Validator(configuration, block))
     }
 
     public class ValidatorWrapper<ValueType>(
-        private val delegate: Validator.Runner<ValueType>,
-    ) : Validator.Runner<ValueType> by delegate {
-        override fun invoke(value: ValueType): ValidationResult<ValueType> {
+        private val delegate: Validator.Runner<ValueType, DefaultMetadataType>,
+    ) : Validator.Runner<ValueType, DefaultMetadataType> by delegate {
+        override fun invoke(value: ValueType): ValidationResult<DefaultMetadataType, ValueType> {
             return delegate(value).also { result ->
                 when (result) {
                     is ValidationResult.Success -> println("Success")

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/Path.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/Path.kt
@@ -17,11 +17,12 @@
 
 package dev.nesk.akkurate
 
+import dev.nesk.akkurate.validatables.GenericValidatable
 import dev.nesk.akkurate.validatables.Validatable
 
 public typealias Path = List<String>
 
-public class PathBuilder(private val validatable: Validatable<*>) {
+public class PathBuilder<MetadataType>(private val validatable: GenericValidatable<*, MetadataType>) {
     public fun absolute(vararg pathSegments: String): Path = pathSegments.toList()
 
     public fun relative(vararg pathSegments: String): Path {
@@ -32,4 +33,4 @@ public class PathBuilder(private val validatable: Validatable<*>) {
     public fun appended(vararg pathSegments: String): Path = validatable.path() + pathSegments.toList()
 }
 
-public fun Validatable<*>.path(block: PathBuilder.() -> Path): Path = PathBuilder(this).block()
+public fun <MetadataType> GenericValidatable<*, MetadataType>.path(block: PathBuilder<MetadataType>.() -> Path): Path = PathBuilder(this).block()

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/Validator.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/Validator.kt
@@ -18,6 +18,8 @@
 package dev.nesk.akkurate
 
 import dev.nesk.akkurate.constraints.*
+import dev.nesk.akkurate.validatables.DefaultMetadataType
+import dev.nesk.akkurate.validatables.GenericValidatable
 import dev.nesk.akkurate.validatables.Validatable
 
 public sealed interface Validator {
@@ -25,53 +27,77 @@ public sealed interface Validator {
         public operator fun <ContextType, ValueType> invoke(
             configuration: Configuration = Configuration(),
             block: Validatable<ValueType>.(context: ContextType) -> Unit,
-        ): Runner.WithContext<ContextType, ValueType> = ValidatorRunner(configuration, block)
+        ): Runner.WithContext<ContextType, ValueType, DefaultMetadataType> = invoke(emptyMap(), configuration, block)
+
+        public operator fun <ContextType, ValueType, MetadataType> invoke(
+            defaultMetadata: MetadataType,
+            configuration: Configuration = Configuration(),
+            block: GenericValidatable<ValueType, MetadataType>.(context: ContextType) -> Unit,
+        ): Runner.WithContext<ContextType, ValueType, MetadataType> = ValidatorRunner(defaultMetadata, configuration, block)
 
         public operator fun <ValueType> invoke(
             configuration: Configuration = Configuration(),
             block: Validatable<ValueType>.() -> Unit,
-        ): Runner<ValueType> = ValidatorRunner.WithoutContext(configuration, block)
+        ): Runner<ValueType, DefaultMetadataType> = invoke(emptyMap(), configuration, block)
+
+        public operator fun <ValueType, MetadataType> invoke(
+            defaultMetadata: MetadataType,
+            configuration: Configuration = Configuration(),
+            block: GenericValidatable<ValueType, MetadataType>.() -> Unit,
+        ): Runner<ValueType, MetadataType> = ValidatorRunner.WithoutContext(defaultMetadata, configuration, block)
 
         public fun <ContextType, ValueType> suspendable(
             configuration: Configuration = Configuration(),
             block: suspend Validatable<ValueType>.(context: ContextType) -> Unit,
-        ): SuspendableRunner.WithContext<ContextType, ValueType> = SuspendableValidatorRunner(configuration, block)
+        ): SuspendableRunner.WithContext<ContextType, ValueType, DefaultMetadataType> = suspendable(emptyMap(), configuration, block)
+
+        public fun <ContextType, ValueType, MetadataType> suspendable(
+            defaultMetadata: MetadataType,
+            configuration: Configuration = Configuration(),
+            block: suspend GenericValidatable<ValueType, MetadataType>.(context: ContextType) -> Unit,
+        ): SuspendableRunner.WithContext<ContextType, ValueType, MetadataType> = SuspendableValidatorRunner(defaultMetadata, configuration, block)
 
         public fun <ValueType> suspendable(
             configuration: Configuration = Configuration(),
             block: suspend Validatable<ValueType>.() -> Unit,
-        ): SuspendableRunner<ValueType> = SuspendableValidatorRunner.WithoutContext(configuration, block)
+        ): SuspendableRunner<ValueType, DefaultMetadataType> = suspendable(emptyMap(), configuration, block)
+
+        public fun <ValueType, MetadataType> suspendable(
+            defaultMetadata: MetadataType,
+            configuration: Configuration = Configuration(),
+            block: suspend GenericValidatable<ValueType, MetadataType>.() -> Unit,
+        ): SuspendableRunner<ValueType, MetadataType> = SuspendableValidatorRunner.WithoutContext(defaultMetadata, configuration, block)
     }
 
-    public sealed interface Runner<ValueType> {
-        public operator fun invoke(value: ValueType): ValidationResult<ValueType>
+    public sealed interface Runner<ValueType, MetadataType> {
+        public operator fun invoke(value: ValueType): ValidationResult<MetadataType, ValueType>
 
-        public sealed interface WithContext<ContextType, ValueType> {
-            public operator fun invoke(context: ContextType): Runner<ValueType>
-            public operator fun invoke(context: ContextType, value: ValueType): ValidationResult<ValueType>
+        public sealed interface WithContext<ContextType, ValueType, MetadataType> {
+            public operator fun invoke(context: ContextType): Runner<ValueType, MetadataType>
+            public operator fun invoke(context: ContextType, value: ValueType): ValidationResult<MetadataType, ValueType>
         }
     }
 
-    public sealed interface SuspendableRunner<ValueType> {
-        public suspend operator fun invoke(value: ValueType): ValidationResult<ValueType>
+    public sealed interface SuspendableRunner<ValueType, MetadataType> {
+        public suspend operator fun invoke(value: ValueType): ValidationResult<MetadataType, ValueType>
 
-        public sealed interface WithContext<ContextType, ValueType> {
-            public operator fun invoke(context: ContextType): SuspendableRunner<ValueType>
-            public suspend operator fun invoke(context: ContextType, value: ValueType): ValidationResult<ValueType>
+        public sealed interface WithContext<ContextType, ValueType, MetadataType> {
+            public operator fun invoke(context: ContextType): SuspendableRunner<ValueType, MetadataType>
+            public suspend operator fun invoke(context: ContextType, value: ValueType): ValidationResult<MetadataType, ValueType>
         }
     }
 }
 
 //region validateWith implementations
 
-public fun <ContextType, ValueType> Validatable<ValueType>.validateWith(
-    validator: Validator.Runner.WithContext<ContextType, ValueType>,
+public fun <ContextType, ValueType, MetadataType> GenericValidatable<ValueType, MetadataType>.validateWith(
+    validator: Validator.Runner.WithContext<ContextType, ValueType, MetadataType>,
     context: ContextType,
 ) {
     validateWith(validator(context))
 }
 
-public fun <ValueType> Validatable<ValueType>.validateWith(validator: Validator.Runner<ValueType>) {
+public fun <ValueType, MetadataType> GenericValidatable<ValueType, MetadataType>.validateWith(validator: Validator.Runner<ValueType, MetadataType>) {
     val result = validator(unwrap())
     if (result is ValidationResult.Failure) {
         result.violations
@@ -80,14 +106,14 @@ public fun <ValueType> Validatable<ValueType>.validateWith(validator: Validator.
     }
 }
 
-public suspend fun <ContextType, ValueType> Validatable<ValueType>.validateWith(
-    validator: Validator.SuspendableRunner.WithContext<ContextType, ValueType>,
+public suspend fun <ContextType, ValueType, MetadataType> GenericValidatable<ValueType, MetadataType>.validateWith(
+    validator: Validator.SuspendableRunner.WithContext<ContextType, ValueType, MetadataType>,
     context: ContextType,
 ) {
     validateWith(validator(context))
 }
 
-public suspend fun <ValueType> Validatable<ValueType>.validateWith(validator: Validator.SuspendableRunner<ValueType>) {
+public suspend fun <ValueType, MetadataType> GenericValidatable<ValueType, MetadataType>.validateWith(validator: Validator.SuspendableRunner<ValueType, MetadataType>) {
     val result = validator(unwrap())
     if (result is ValidationResult.Failure) {
         result.violations
@@ -100,69 +126,75 @@ public suspend fun <ValueType> Validatable<ValueType>.validateWith(validator: Va
 
 //region Private API
 
-private class ValidatorRunner<ContextType, ValueType>(
+private class ValidatorRunner<ContextType, ValueType, MetadataType>(
+    private val defaultMetadata: MetadataType,
     private val configuration: Configuration,
-    private val block: Validatable<ValueType>.(context: ContextType) -> Unit,
-) : Validator.Runner.WithContext<ContextType, ValueType> {
+    private val block: GenericValidatable<ValueType, MetadataType>.(context: ContextType) -> Unit,
+) : Validator.Runner.WithContext<ContextType, ValueType, MetadataType> {
 
-    override operator fun invoke(context: ContextType) = Contextualized(configuration, context, block)
+    override operator fun invoke(context: ContextType) = Contextualized(defaultMetadata, configuration, context, block)
 
-    override operator fun invoke(context: ContextType, value: ValueType): ValidationResult<ValueType> = invoke(context)(value)
+    override operator fun invoke(context: ContextType, value: ValueType): ValidationResult<MetadataType, ValueType> = invoke(context)(value)
 
-    class Contextualized<ContextType, ValueType>(
+    class Contextualized<ContextType, ValueType, MetadataType>(
+        private val defaultMetadata: MetadataType,
         private val configuration: Configuration,
         private val context: ContextType,
-        private val block: Validatable<ValueType>.(context: ContextType) -> Unit,
-    ) : Validator.Runner<ValueType> {
-        override operator fun invoke(value: ValueType): ValidationResult<ValueType> =
+        private val block: GenericValidatable<ValueType, MetadataType>.(context: ContextType) -> Unit,
+    ) : Validator.Runner<ValueType, MetadataType> {
+        override operator fun invoke(value: ValueType): ValidationResult<MetadataType, ValueType> =
             runWithConstraintRegistry(value, configuration) { registry ->
                 val block = this.block
-                Validatable(value, registry).run { block(context) }
+                GenericValidatable<ValueType, MetadataType>(value, registry, defaultMetadata).run { block(context) }
             }
     }
 
-    class WithoutContext<ValueType>(
+    class WithoutContext<ValueType, MetadataType>(
+        private val defaultMetadata: MetadataType,
         private val configuration: Configuration,
-        private val block: Validatable<ValueType>.() -> Unit,
-    ) : Validator.Runner<ValueType> {
-        override operator fun invoke(value: ValueType): ValidationResult<ValueType> =
+        private val block: GenericValidatable<ValueType, MetadataType>.() -> Unit,
+    ) : Validator.Runner<ValueType, MetadataType> {
+        override operator fun invoke(value: ValueType): ValidationResult<MetadataType, ValueType> =
             runWithConstraintRegistry(value, configuration) { registry ->
                 val block = this.block
-                Validatable(value, registry).run { block() }
+                GenericValidatable<ValueType, MetadataType>(value, registry, defaultMetadata).run { block() }
             }
     }
 
 }
 
-private class SuspendableValidatorRunner<ContextType, ValueType>(
+private class SuspendableValidatorRunner<ContextType, ValueType, MetadataType>(
+    private val defaultMetadata: MetadataType,
     private val configuration: Configuration,
-    private val block: suspend Validatable<ValueType>.(context: ContextType) -> Unit,
-) : Validator.SuspendableRunner.WithContext<ContextType, ValueType> {
+    private val block: suspend GenericValidatable<ValueType, MetadataType>.(context: ContextType) -> Unit,
+) : Validator.SuspendableRunner.WithContext<ContextType, ValueType, MetadataType> {
 
-    override operator fun invoke(context: ContextType) = Contextualized(configuration, context, block)
+    override operator fun invoke(context: ContextType) = Contextualized(defaultMetadata, configuration, context, block)
 
-    override suspend operator fun invoke(context: ContextType, value: ValueType): ValidationResult<ValueType> = invoke(context)(value)
+    override suspend operator fun invoke(context: ContextType, value: ValueType): ValidationResult<MetadataType, ValueType> = invoke(context)(value)
 
-    class Contextualized<ContextType, ValueType>(
+    class Contextualized<ContextType, ValueType, MetadataType>(
+        private val defaultMetadata: MetadataType,
         private val configuration: Configuration,
         private val context: ContextType,
-        private val block: suspend Validatable<ValueType>.(context: ContextType) -> Unit,
-    ) : Validator.SuspendableRunner<ValueType> {
-        override suspend operator fun invoke(value: ValueType): ValidationResult<ValueType> =
+        private val block: suspend GenericValidatable<ValueType, MetadataType>.(context: ContextType) -> Unit,
+    ) : Validator.SuspendableRunner<ValueType, MetadataType> {
+        override suspend operator fun invoke(value: ValueType): ValidationResult<MetadataType, ValueType> =
             runWithConstraintRegistry(value, configuration) { registry ->
                 val block = this.block
-                Validatable(value, registry).run { block(context) }
+                GenericValidatable(value, registry, defaultMetadata).run { block(context) }
             }
     }
 
-    class WithoutContext<ValueType>(
+    class WithoutContext<ValueType, MetadataType>(
+        private val defaultMetadata: MetadataType,
         private val configuration: Configuration,
-        private val block: suspend Validatable<ValueType>.() -> Unit,
-    ) : Validator.SuspendableRunner<ValueType> {
-        override suspend operator fun invoke(value: ValueType): ValidationResult<ValueType> =
+        private val block: suspend GenericValidatable<ValueType, MetadataType>.() -> Unit,
+    ) : Validator.SuspendableRunner<ValueType, MetadataType> {
+        override suspend operator fun invoke(value: ValueType): ValidationResult<MetadataType, ValueType> =
             runWithConstraintRegistry(value, configuration) { registry ->
                 val block = this.block
-                Validatable(value, registry).run { block() }
+                GenericValidatable(value, registry, defaultMetadata).run { block() }
             }
     }
 

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/accessors/Array.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/accessors/Array.kt
@@ -17,10 +17,11 @@
 
 package dev.nesk.akkurate.accessors
 
+import dev.nesk.akkurate.validatables.GenericValidatable
 import dev.nesk.akkurate.validatables.Validatable
 import dev.nesk.akkurate.validatables.validatableOf
 
-public operator fun <T> Validatable<Array<T>?>.get(index: Int): Validatable<T?> {
+public operator fun <T, MetadataType> GenericValidatable<Array<T>?, MetadataType>.get(index: Int): GenericValidatable<T?, MetadataType> {
     val wrappedValue = unwrap()?.let {
         if (index in it.indices) {
             it[index]
@@ -28,17 +29,17 @@ public operator fun <T> Validatable<Array<T>?>.get(index: Int): Validatable<T?> 
             null
         }
     }
-    return Validatable(wrappedValue, index.toString(), this)
+    return GenericValidatable(wrappedValue, index.toString(), this)
 }
 
-public fun <T> Validatable<Array<T>?>.first(): Validatable<T?> = try {
+public fun <T, MetadataType> GenericValidatable<Array<T>?, MetadataType>.first(): GenericValidatable<T?, MetadataType> = try {
     validatableOf(Array<T>::first)
 } catch (e: NoSuchElementException) {
-    Validatable(null, "first", this)
+    GenericValidatable(null, "first", this)
 }
 
-public fun <T> Validatable<Array<T>?>.last(): Validatable<T?> = try {
+public fun <T, MetadataType> GenericValidatable<Array<T>?, MetadataType>.last(): GenericValidatable<T?, MetadataType> = try {
     validatableOf(Array<T>::last)
 } catch (e: NoSuchElementException) {
-    Validatable(null, "last", this)
+    GenericValidatable(null, "last", this)
 }

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/accessors/Iterable.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/accessors/Iterable.kt
@@ -17,7 +17,7 @@
 
 package dev.nesk.akkurate.accessors
 
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.validatables.GenericValidatable
 import dev.nesk.akkurate.validatables.validatableOf
 
 private val emptyIterator = object : Iterator<Nothing> {
@@ -26,40 +26,40 @@ private val emptyIterator = object : Iterator<Nothing> {
 }
 
 /**
- * Returns an iterator over the elements of this object. Each element is wrapped with a [Validatable].
+ * Returns an iterator over the elements of this object. Each element is wrapped with a [GenericValidatable].
  */
-public operator fun <T> Validatable<Iterable<T>?>.iterator(): Iterator<Validatable<T>> = unwrap()?.let { iterable ->
+public operator fun <T, MetadataType> GenericValidatable<Iterable<T>?, MetadataType>.iterator(): Iterator<GenericValidatable<T, MetadataType>> = unwrap()?.let { iterable ->
     iterable
         .asSequence()
         .withIndex()
-        .map { Validatable(it.value, it.index.toString(), this) }
+        .map { GenericValidatable(it.value, it.index.toString(), this) }
         .iterator()
 } ?: emptyIterator
 
 /**
- * Returns the first element, wrapped in [Validatable].
+ * Returns the first element, wrapped in [GenericValidatable].
  *
  * The wrapped value is `null` if the collection is empty.
  */
-public fun <T> Validatable<Iterable<T>?>.first(): Validatable<T?> = try {
+public fun <T, MetadataType> GenericValidatable<Iterable<T>?, MetadataType>.first(): GenericValidatable<T?, MetadataType> = try {
     validatableOf(Iterable<T>::first)
 } catch (e: NoSuchElementException) {
-    Validatable(null, "first", this)
+    GenericValidatable(null, "first", this)
 }
 
 /**
- * Returns the last element, wrapped in [Validatable].
+ * Returns the last element, wrapped in [GenericValidatable].
  *
  * The wrapped value is `null` if the collection is empty.
  */
-public fun <T> Validatable<Iterable<T>?>.last(): Validatable<T?> = try {
+public fun <T, MetadataType> GenericValidatable<Iterable<T>?, MetadataType>.last(): GenericValidatable<T?, MetadataType> = try {
     validatableOf(Iterable<T>::last)
 } catch (e: NoSuchElementException) {
-    Validatable(null, "last", this)
+    GenericValidatable(null, "last", this)
 }
 
 /**
- * Iterates over each element of this object and wraps them with a [Validatable] before passing them to the [block].
+ * Iterates over each element of this object and wraps them with a [GenericValidatable] before passing them to the [block].
  *
  * ```
  * Validator<List<String>> {
@@ -68,6 +68,6 @@ public fun <T> Validatable<Iterable<T>?>.last(): Validatable<T?> = try {
  * }
  * ```
  */
-public inline fun <T> Validatable<Iterable<T>?>.each(block: Validatable<T>.() -> Unit) {
+public inline fun <T, MetadataType> GenericValidatable<Iterable<T>?, MetadataType>.each(block: GenericValidatable<T, MetadataType>.() -> Unit) {
     for (row in this) row.invoke(block)
 }

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/accessors/List.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/accessors/List.kt
@@ -17,12 +17,12 @@
 
 package dev.nesk.akkurate.accessors
 
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.validatables.GenericValidatable
 
 /**
- * Returns the element at the specified index in the list, wrapped in a [Validatable].
+ * Returns the element at the specified index in the list, wrapped in a [GenericValidatable].
  */
-public operator fun <T> Validatable<List<T>?>.get(index: Int): Validatable<T?> {
+public operator fun <T, MetadataType> GenericValidatable<List<T>?, MetadataType>.get(index: Int): GenericValidatable<T?, MetadataType> {
     val wrappedValue = unwrap()?.let {
         if (index in it.indices) {
             it[index]
@@ -30,5 +30,5 @@ public operator fun <T> Validatable<List<T>?>.get(index: Int): Validatable<T?> {
             null
         }
     }
-    return Validatable(wrappedValue, index.toString(), this)
+    return GenericValidatable(wrappedValue, index.toString(), this)
 }

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/accessors/Map.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/accessors/Map.kt
@@ -17,7 +17,7 @@
 
 package dev.nesk.akkurate.accessors
 
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.validatables.GenericValidatable
 
-public operator fun <K, V> Validatable<Map<K, V>?>.get(index: K): Validatable<V?> =
-    Validatable(unwrap()?.get(index), index.toString(), this)
+public operator fun <K, V, MetadataType> GenericValidatable<Map<K, V>?, MetadataType>.get(index: K): GenericValidatable<V?, MetadataType> =
+    GenericValidatable(unwrap()?.get(index), index.toString(), this)

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/ConstraintDescriptor.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/ConstraintDescriptor.kt
@@ -18,8 +18,12 @@
 package dev.nesk.akkurate.constraints
 
 import dev.nesk.akkurate.Path
+import dev.nesk.akkurate.validatables.DefaultMetadataType
 
-public sealed interface ConstraintDescriptor {
+public typealias ConstraintDescriptor = GenericConstraintDescriptor<DefaultMetadataType>
+
+public sealed interface GenericConstraintDescriptor<MetadataType> {
     public val message: String
     public val path: Path
+    public val metadata: MetadataType
 }

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/ConstraintViolation.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/ConstraintViolation.kt
@@ -18,20 +18,29 @@
 package dev.nesk.akkurate.constraints
 
 import dev.nesk.akkurate.Path
+import dev.nesk.akkurate.validatables.DefaultMetadataType
 
-public class ConstraintViolation(public override val message: String, public override val path: Path) : ConstraintDescriptor {
+public typealias ConstraintViolation = GenericConstraintViolation<DefaultMetadataType>
+
+public class GenericConstraintViolation<MetadataType>(
+    public override val message: String,
+    public override val path: Path,
+    override val metadata: MetadataType
+) : GenericConstraintDescriptor<MetadataType> {
     public operator fun component1(): String = message
     public operator fun component2(): Path = path
 
-    internal fun copy(path: Path = this.path) = ConstraintViolation(message, path)
+    internal fun copy(path: Path = this.path): GenericConstraintViolation<MetadataType> = GenericConstraintViolation(message, path, metadata)
+    internal fun <NEW_META> copy(metadata: NEW_META): GenericConstraintViolation<NEW_META> = GenericConstraintViolation(message, path, metadata)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false
 
-        other as ConstraintViolation
+        other as GenericConstraintViolation<MetadataType>
 
         if (message != other.message) return false
+        if (metadata != other.metadata) return false
         return path == other.path
     }
 
@@ -41,5 +50,10 @@ public class ConstraintViolation(public override val message: String, public ove
         return result
     }
 
-    override fun toString(): String = "ConstraintViolation(message='$message', path=$path)"
+    override fun toString(): String = "ConstraintViolation(message='$message', path=$path, metadata=$metadata)"
+
+    public companion object {
+        public operator fun invoke(message: String, path: Path): ConstraintViolation =
+            GenericConstraintViolation(message, path, emptyMap())
+    }
 }

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/ConstraintViolationSet.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/ConstraintViolationSet.kt
@@ -18,9 +18,12 @@
 package dev.nesk.akkurate.constraints
 
 import dev.nesk.akkurate.Path
+import dev.nesk.akkurate.validatables.DefaultMetadataType
 
-public class ConstraintViolationSet(private val messages: Set<ConstraintViolation>) : Set<ConstraintViolation> by messages {
-    public val byPath: Map<Path, Set<ConstraintViolation>> by lazy { messages.groupBy { it.path }.mapValues { it.value.toSet() } }
+public typealias ConstraintViolationSet = GenericConstraintViolationSet<DefaultMetadataType>
+
+public class GenericConstraintViolationSet<MetadataType>(private val messages: Set<GenericConstraintViolation<MetadataType>>) : Set<GenericConstraintViolation<MetadataType>> by messages {
+    public val byPath: Map<Path, Set<GenericConstraintViolation<MetadataType>>> by lazy { messages.groupBy { it.path }.mapValues { it.value.toSet() } }
 
     override fun equals(other: Any?): Boolean = messages == other
 

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Any.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Any.kt
@@ -18,9 +18,13 @@
 package dev.nesk.akkurate.constraints.builders
 
 import dev.nesk.akkurate.constraints.Constraint
+import dev.nesk.akkurate.constraints.GenericConstraint
 import dev.nesk.akkurate.constraints.constrain
 import dev.nesk.akkurate.constraints.otherwise
+import dev.nesk.akkurate.validatables.DefaultMetadataType
+import dev.nesk.akkurate.validatables.GenericValidatable
 import dev.nesk.akkurate.validatables.Validatable
+import kotlin.jvm.JvmName
 
 /**
  * The validatable value must be null when this constraint is applied.
@@ -33,7 +37,7 @@ import dev.nesk.akkurate.validatables.Validatable
  * validate(1234) // Failure (message: Must be null)
  * ```
  */
-public fun <T> Validatable<T?>.isNull(): Constraint = constrain { it == null } otherwise { "Must be null" }
+public fun <T, MetadataType> GenericValidatable<T?, MetadataType>.isNull(): GenericConstraint<MetadataType> = constrain { it == null } otherwise { "Must be null" }
 
 /**
  * The validatable value must not be null when this constraint is applied.
@@ -46,7 +50,7 @@ public fun <T> Validatable<T?>.isNull(): Constraint = constrain { it == null } o
  * validate(null) // Failure (message: Must not be null)
  * ```
  */
-public fun <T> Validatable<T?>.isNotNull(): Constraint = constrain { it != null } otherwise { "Must not be null" }
+public fun <T, MetadataType> GenericValidatable<T?, MetadataType>.isNotNull(): GenericConstraint<MetadataType> = constrain { it != null } otherwise { "Must not be null" }
 
 /**
  * The validatable value must be equal to [other] when this constraint is applied.
@@ -59,7 +63,7 @@ public fun <T> Validatable<T?>.isNotNull(): Constraint = constrain { it != null 
  * validate("bar") // Failure (message: Must be equal to "foo")
  * ```
  */
-public fun <T> Validatable<T?>.isEqualTo(other: T?): Constraint = constrain { it == other } otherwise { "Must be equal to \"$other\"" }
+public fun <T, MetadataType> GenericValidatable<T?, MetadataType>.isEqualTo(other: T?): GenericConstraint<MetadataType> = constrain { it == other } otherwise { "Must be equal to \"$other\"" }
 
 /**
  * The validatable value must be equal to [other] when this constraint is applied.
@@ -72,7 +76,7 @@ public fun <T> Validatable<T?>.isEqualTo(other: T?): Constraint = constrain { it
  * validate("foo" to "bar") // Failure (message: Must be equal to "bar")
  * ```
  */
-public fun <T> Validatable<T?>.isEqualTo(other: Validatable<T>): Constraint = constrain { it == other.unwrap() } otherwise { "Must be equal to \"${other.unwrap()}\"" }
+public fun <T, MetadataType> GenericValidatable<T?, MetadataType>.isEqualTo(other: Validatable<T>): GenericConstraint<MetadataType> = constrain { it == other.unwrap() } otherwise { "Must be equal to \"${other.unwrap()}\"" }
 
 /**
  * The validatable value must be different from [other] when this constraint is applied.
@@ -85,7 +89,7 @@ public fun <T> Validatable<T?>.isEqualTo(other: Validatable<T>): Constraint = co
  * validate("foo") // Failure (message: Must be different from "foo")
  * ```
  */
-public fun <T> Validatable<T?>.isNotEqualTo(other: T?): Constraint = constrain { it != other } otherwise { "Must be different from \"$other\"" }
+public fun <T, MetadataType> GenericValidatable<T?, MetadataType>.isNotEqualTo(other: T?): GenericConstraint<MetadataType> = constrain { it != other } otherwise { "Must be different from \"$other\"" }
 
 /**
  * The validatable value must be different from [other] when this constraint is applied.
@@ -98,7 +102,7 @@ public fun <T> Validatable<T?>.isNotEqualTo(other: T?): Constraint = constrain {
  * validate("foo" to "foo") // Failure (message: Must be different from "foo")
  * ```
  */
-public fun <T> Validatable<T?>.isNotEqualTo(other: Validatable<T>): Constraint = constrain { it != other.unwrap() } otherwise { "Must be different from \"${other.unwrap()}\"" }
+public fun <T, MetadataType> GenericValidatable<T?, MetadataType>.isNotEqualTo(other: Validatable<T>): GenericConstraint<MetadataType> = constrain { it != other.unwrap() } otherwise { "Must be different from \"${other.unwrap()}\"" }
 
 /**
  * The validatable value must be identical to [other] when this constraint is applied.
@@ -116,7 +120,7 @@ public fun <T> Validatable<T?>.isNotEqualTo(other: Validatable<T>): Constraint =
  * validate(Bar) // Failure (message: Must be identical to "Foo")
  * ```
  */
-public fun <T> Validatable<T?>.isIdenticalTo(other: T?): Constraint = constrain { it === other } otherwise { "Must be identical to \"$other\"" }
+public fun <T, MetadataType> GenericValidatable<T?, MetadataType>.isIdenticalTo(other: T?): GenericConstraint<MetadataType> = constrain { it === other } otherwise { "Must be identical to \"$other\"" }
 
 /**
  * The validatable value must not be identical to [other] when this constraint is applied.
@@ -134,7 +138,7 @@ public fun <T> Validatable<T?>.isIdenticalTo(other: T?): Constraint = constrain 
  * validate(Foo) // Failure (message: Must not be identical to "Foo")
  * ```
  */
-public fun <T> Validatable<T?>.isNotIdenticalTo(other: T?): Constraint = constrain { it !== other } otherwise { "Must not be identical to \"$other\"" }
+public fun <T, MetadataType> GenericValidatable<T?, MetadataType>.isNotIdenticalTo(other: T?): GenericConstraint<MetadataType> = constrain { it !== other } otherwise { "Must not be identical to \"$other\"" }
 
 /**
  * The validatable value must be an instance of type parameter R when this constraint is applied.
@@ -148,6 +152,10 @@ public fun <T> Validatable<T?>.isNotIdenticalTo(other: T?): Constraint = constra
  * ```
  */
 public inline fun <reified T> Validatable<*>.isInstanceOf(): Constraint =
+    this.isInstanceOf<T, DefaultMetadataType>()
+
+@JvmName("genericIsInstanceOf")
+public inline fun <reified T, MetadataType> GenericValidatable<*, MetadataType>.isInstanceOf(): GenericConstraint<MetadataType> =
     constrain { it is T } otherwise { "Must be an instance of \"${T::class.simpleName}\"" }
 
 /**
@@ -162,4 +170,8 @@ public inline fun <reified T> Validatable<*>.isInstanceOf(): Constraint =
  * ```
  */
 public inline fun <reified T> Validatable<*>.isNotInstanceOf(): Constraint =
+    this.isNotInstanceOf<T, DefaultMetadataType>()
+
+@JvmName("genericIsNotInstanceOf")
+public inline fun <reified T, MetadataType> GenericValidatable<*, MetadataType>.isNotInstanceOf(): GenericConstraint<MetadataType> =
     constrain { it !is T } otherwise { "Must not be an instance of \"${T::class.simpleName}\"" }

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Array.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Array.kt
@@ -17,10 +17,10 @@
 
 package dev.nesk.akkurate.constraints.builders
 
-import dev.nesk.akkurate.constraints.Constraint
+import dev.nesk.akkurate.constraints.GenericConstraint
 import dev.nesk.akkurate.constraints.constrainIfNotNull
 import dev.nesk.akkurate.constraints.otherwise
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.validatables.GenericValidatable
 import kotlin.jvm.JvmName
 
 /*
@@ -44,7 +44,7 @@ import kotlin.jvm.JvmName
  * ```
  */
 @JvmName("arrayIsEmpty")
-public fun <T> Validatable<Array<out T>?>.isEmpty(): Constraint =
+public fun <T, MetadataType> GenericValidatable<Array<out T>?, MetadataType>.isEmpty(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isEmpty() } otherwise { "Must be empty" }
 
 /**
@@ -59,7 +59,7 @@ public fun <T> Validatable<Array<out T>?>.isEmpty(): Constraint =
  * ```
  */
 @JvmName("arrayIsNotEmpty")
-public fun <T> Validatable<Array<out T>?>.isNotEmpty(): Constraint =
+public fun <T, MetadataType> GenericValidatable<Array<out T>?, MetadataType>.isNotEmpty(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isNotEmpty() } otherwise { "Must not be empty" }
 
 /**
@@ -74,7 +74,7 @@ public fun <T> Validatable<Array<out T>?>.isNotEmpty(): Constraint =
  * ```
  */
 @JvmName("arrayHasSizeEqualTo")
-public fun <T> Validatable<Array<out T>?>.hasSizeEqualTo(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Array<out T>?, MetadataType>.hasSizeEqualTo(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size == size } otherwise { "The number of items must be equal to $size" }
 
 /**
@@ -89,7 +89,7 @@ public fun <T> Validatable<Array<out T>?>.hasSizeEqualTo(size: Int): Constraint 
  * ```
  */
 @JvmName("arrayHasSizeNotEqualTo")
-public fun <T> Validatable<Array<out T>?>.hasSizeNotEqualTo(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Array<out T>?, MetadataType>.hasSizeNotEqualTo(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size != size } otherwise { "The number of items must be different from $size" }
 
 /**
@@ -104,7 +104,7 @@ public fun <T> Validatable<Array<out T>?>.hasSizeNotEqualTo(size: Int): Constrai
  * ```
  */
 @JvmName("arrayHasSizeLowerThan")
-public fun <T> Validatable<Array<out T>?>.hasSizeLowerThan(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Array<out T>?, MetadataType>.hasSizeLowerThan(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size < size } otherwise { "The number of items must be lower than $size" }
 
 /**
@@ -120,7 +120,7 @@ public fun <T> Validatable<Array<out T>?>.hasSizeLowerThan(size: Int): Constrain
  * ```
  */
 @JvmName("arrayHasSizeLowerThanOrEqualTo")
-public fun <T> Validatable<Array<out T>?>.hasSizeLowerThanOrEqualTo(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Array<out T>?, MetadataType>.hasSizeLowerThanOrEqualTo(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size <= size } otherwise { "The number of items must be lower than or equal to $size" }
 
 /**
@@ -135,7 +135,7 @@ public fun <T> Validatable<Array<out T>?>.hasSizeLowerThanOrEqualTo(size: Int): 
  * ```
  */
 @JvmName("arrayHasSizeGreaterThan")
-public fun <T> Validatable<Array<out T>?>.hasSizeGreaterThan(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Array<out T>?, MetadataType>.hasSizeGreaterThan(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size > size } otherwise { "The number of items must be greater than $size" }
 
 /**
@@ -151,7 +151,7 @@ public fun <T> Validatable<Array<out T>?>.hasSizeGreaterThan(size: Int): Constra
  * ```
  */
 @JvmName("arrayHasSizeGreaterThanOrEqualTo")
-public fun <T> Validatable<Array<out T>?>.hasSizeGreaterThanOrEqualTo(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Array<out T>?, MetadataType>.hasSizeGreaterThanOrEqualTo(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size >= size } otherwise { "The number of items must be greater than or equal to $size" }
 
 /**
@@ -168,7 +168,7 @@ public fun <T> Validatable<Array<out T>?>.hasSizeGreaterThanOrEqualTo(size: Int)
  * ```
  */
 @JvmName("arrayHasSizeBetween")
-public fun <T> Validatable<Array<out T>?>.hasSizeBetween(range: IntRange): Constraint =
+public fun <T, MetadataType> GenericValidatable<Array<out T>?, MetadataType>.hasSizeBetween(range: IntRange): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size in range } otherwise { "The number of items must be between ${range.first} and ${range.last}" }
 
 /**
@@ -183,7 +183,7 @@ public fun <T> Validatable<Array<out T>?>.hasSizeBetween(range: IntRange): Const
  * ```
  */
 @JvmName("arrayIsContaining")
-public fun <T> Validatable<Array<out T>?>.isContaining(element: T): Constraint =
+public fun <T, MetadataType> GenericValidatable<Array<out T>?, MetadataType>.isContaining(element: T): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.contains(element) } otherwise { "Must contain \"$element\"" }
 
 /**
@@ -198,7 +198,7 @@ public fun <T> Validatable<Array<out T>?>.isContaining(element: T): Constraint =
  * ```
  */
 @JvmName("arrayIsNotContaining")
-public fun <T> Validatable<Array<out T>?>.isNotContaining(element: T): Constraint =
+public fun <T, MetadataType> GenericValidatable<Array<out T>?, MetadataType>.isNotContaining(element: T): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.contains(element) } otherwise { "Must not contain \"$element\"" }
 
 /**
@@ -212,5 +212,5 @@ public fun <T> Validatable<Array<out T>?>.isNotContaining(element: T): Constrain
  * validate(arrayOf('a', 'b', 'c', 'a')) // Failure (message: Must contain unique elements)
  * ```
  */
-public fun <T> Validatable<Array<out T>?>.hasNoDuplicates(): Constraint =
+public fun <T, MetadataType> GenericValidatable<Array<out T>?, MetadataType>.hasNoDuplicates(): GenericConstraint<MetadataType> =
     constrainIfNotNull { array -> array.toSet().size == array.size } otherwise { "Must contain unique elements" }

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Boolean.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Boolean.kt
@@ -17,13 +17,19 @@
 
 package dev.nesk.akkurate.constraints.builders
 
-import dev.nesk.akkurate.constraints.Constraint
+import dev.nesk.akkurate.constraints.GenericConstraint
 import dev.nesk.akkurate.constraints.constrain
 import dev.nesk.akkurate.constraints.otherwise
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.validatables.GenericValidatable
 
-public fun Validatable<Boolean?>.isTrue(): Constraint = constrain { it == true } otherwise { "Must be true" }
-public fun Validatable<Boolean?>.isNotTrue(): Constraint = constrain { it != true } otherwise { "Must not be true" }
+public fun <MetadataType> GenericValidatable<Boolean?, MetadataType>.isTrue(): GenericConstraint<MetadataType> =
+    constrain { it == true } otherwise { "Must be true" }
 
-public fun Validatable<Boolean?>.isFalse(): Constraint = constrain { it == false } otherwise { "Must be false" }
-public fun Validatable<Boolean?>.isNotFalse(): Constraint = constrain { it != false } otherwise { "Must not be false" }
+public fun <MetadataType> GenericValidatable<Boolean?, MetadataType>.isNotTrue(): GenericConstraint<MetadataType> =
+    constrain { it != true } otherwise { "Must not be true" }
+
+public fun <MetadataType> GenericValidatable<Boolean?, MetadataType>.isFalse(): GenericConstraint<MetadataType> =
+    constrain { it == false } otherwise { "Must be false" }
+
+public fun <MetadataType> GenericValidatable<Boolean?, MetadataType>.isNotFalse(): GenericConstraint<MetadataType> =
+    constrain { it != false } otherwise { "Must not be false" }

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/CharSequence.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/CharSequence.kt
@@ -17,64 +17,64 @@
 
 package dev.nesk.akkurate.constraints.builders
 
-import dev.nesk.akkurate.constraints.Constraint
+import dev.nesk.akkurate.constraints.GenericConstraint
 import dev.nesk.akkurate.constraints.constrainIfNotNull
 import dev.nesk.akkurate.constraints.otherwise
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.validatables.GenericValidatable
 
-public fun Validatable<CharSequence?>.isEmpty(): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.isEmpty(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isEmpty() } otherwise { "Must be empty" }
 
-public fun Validatable<CharSequence?>.isNotEmpty(): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.isNotEmpty(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isNotEmpty() } otherwise { "Must not be empty" }
 
-public fun Validatable<CharSequence?>.isBlank(): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.isBlank(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isBlank() } otherwise { "Must be blank" }
 
-public fun Validatable<CharSequence?>.isNotBlank(): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.isNotBlank(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isNotBlank() } otherwise { "Must not be blank" }
 
-public fun Validatable<CharSequence?>.hasLengthEqualTo(length: Int): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.hasLengthEqualTo(length: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.length == length } otherwise { "Length must be equal to $length" }
 
-public fun Validatable<CharSequence?>.hasLengthNotEqualTo(length: Int): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.hasLengthNotEqualTo(length: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.length != length } otherwise { "Length must be different from $length" }
 
-public fun Validatable<CharSequence?>.hasLengthLowerThan(length: Int): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.hasLengthLowerThan(length: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.length < length } otherwise { "Length must be lower than $length" }
 
-public fun Validatable<CharSequence?>.hasLengthLowerThanOrEqualTo(length: Int): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.hasLengthLowerThanOrEqualTo(length: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.length <= length } otherwise { "Length must be lower than or equal to $length" }
 
-public fun Validatable<CharSequence?>.hasLengthGreaterThan(length: Int): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.hasLengthGreaterThan(length: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.length > length } otherwise { "Length must be greater than $length" }
 
-public fun Validatable<CharSequence?>.hasLengthGreaterThanOrEqualTo(length: Int): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.hasLengthGreaterThanOrEqualTo(length: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.length >= length } otherwise { "Length must be greater than or equal to $length" }
 
-public fun Validatable<CharSequence?>.hasLengthBetween(range: IntRange): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.hasLengthBetween(range: IntRange): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.length in range } otherwise { "Length must be between ${range.first} and ${range.last}" }
 
-public fun Validatable<CharSequence?>.isMatching(regex: Regex): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.isMatching(regex: Regex): GenericConstraint<MetadataType> =
     constrainIfNotNull { regex.matches(it) } otherwise { "Must match the following pattern: ${regex.pattern}" }
 
-public fun Validatable<CharSequence?>.isNotMatching(regex: Regex): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.isNotMatching(regex: Regex): GenericConstraint<MetadataType> =
     constrainIfNotNull { !regex.matches(it) } otherwise { "Must not match the following pattern: ${regex.pattern}" }
 
-public fun Validatable<CharSequence?>.isStartingWith(prefix: CharSequence): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.isStartingWith(prefix: CharSequence): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.startsWith(prefix) } otherwise { "Must start with \"$prefix\"" }
 
-public fun Validatable<CharSequence?>.isNotStartingWith(prefix: CharSequence): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.isNotStartingWith(prefix: CharSequence): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.startsWith(prefix) } otherwise { "Must not start with \"$prefix\"" }
 
-public fun Validatable<CharSequence?>.isEndingWith(suffix: CharSequence): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.isEndingWith(suffix: CharSequence): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.endsWith(suffix) } otherwise { "Must end with \"$suffix\"" }
 
-public fun Validatable<CharSequence?>.isNotEndingWith(suffix: CharSequence): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.isNotEndingWith(suffix: CharSequence): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.endsWith(suffix) } otherwise { "Must not end with \"$suffix\"" }
 
-public fun Validatable<CharSequence?>.isContaining(other: CharSequence): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.isContaining(other: CharSequence): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.contains(other) } otherwise { "Must contain \"$other\"" }
 
-public fun Validatable<CharSequence?>.isNotContaining(other: CharSequence): Constraint =
+public fun <MetadataType> GenericValidatable<CharSequence?, MetadataType>.isNotContaining(other: CharSequence): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.contains(other) } otherwise { "Must not contain \"$other\"" }

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Collection.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Collection.kt
@@ -17,10 +17,10 @@
 
 package dev.nesk.akkurate.constraints.builders
 
-import dev.nesk.akkurate.constraints.Constraint
+import dev.nesk.akkurate.constraints.GenericConstraint
 import dev.nesk.akkurate.constraints.constrainIfNotNull
 import dev.nesk.akkurate.constraints.otherwise
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.validatables.GenericValidatable
 import kotlin.jvm.JvmName
 
 /*
@@ -44,7 +44,7 @@ import kotlin.jvm.JvmName
  * ```
  */
 @JvmName("collectionIsEmpty")
-public fun <T> Validatable<Collection<T>?>.isEmpty(): Constraint =
+public fun <T, MetadataType> GenericValidatable<Collection<T>?, MetadataType>.isEmpty(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isEmpty() } otherwise { "Must be empty" }
 
 /**
@@ -59,7 +59,7 @@ public fun <T> Validatable<Collection<T>?>.isEmpty(): Constraint =
  * ```
  */
 @JvmName("collectionIsNotEmpty")
-public fun <T> Validatable<Collection<T>?>.isNotEmpty(): Constraint =
+public fun <T, MetadataType> GenericValidatable<Collection<T>?, MetadataType>.isNotEmpty(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isNotEmpty() } otherwise { "Must not be empty" }
 
 /**
@@ -74,7 +74,7 @@ public fun <T> Validatable<Collection<T>?>.isNotEmpty(): Constraint =
  * ```
  */
 @JvmName("collectionHasSizeEqualTo")
-public fun <T> Validatable<Collection<T>?>.hasSizeEqualTo(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Collection<T>?, MetadataType>.hasSizeEqualTo(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size == size } otherwise { "The number of items must be equal to $size" }
 
 /**
@@ -89,7 +89,7 @@ public fun <T> Validatable<Collection<T>?>.hasSizeEqualTo(size: Int): Constraint
  * ```
  */
 @JvmName("collectionHasSizeNotEqualTo")
-public fun <T> Validatable<Collection<T>?>.hasSizeNotEqualTo(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Collection<T>?, MetadataType>.hasSizeNotEqualTo(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size != size } otherwise { "The number of items must be different from $size" }
 
 /**
@@ -104,7 +104,7 @@ public fun <T> Validatable<Collection<T>?>.hasSizeNotEqualTo(size: Int): Constra
  * ```
  */
 @JvmName("collectionHasSizeLowerThan")
-public fun <T> Validatable<Collection<T>?>.hasSizeLowerThan(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Collection<T>?, MetadataType>.hasSizeLowerThan(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size < size } otherwise { "The number of items must be lower than $size" }
 
 /**
@@ -120,7 +120,7 @@ public fun <T> Validatable<Collection<T>?>.hasSizeLowerThan(size: Int): Constrai
  * ```
  */
 @JvmName("collectionHasSizeLowerThanOrEqualTo")
-public fun <T> Validatable<Collection<T>?>.hasSizeLowerThanOrEqualTo(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Collection<T>?, MetadataType>.hasSizeLowerThanOrEqualTo(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size <= size } otherwise { "The number of items must be lower than or equal to $size" }
 
 /**
@@ -135,7 +135,7 @@ public fun <T> Validatable<Collection<T>?>.hasSizeLowerThanOrEqualTo(size: Int):
  * ```
  */
 @JvmName("collectionHasSizeGreaterThan")
-public fun <T> Validatable<Collection<T>?>.hasSizeGreaterThan(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Collection<T>?, MetadataType>.hasSizeGreaterThan(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size > size } otherwise { "The number of items must be greater than $size" }
 
 /**
@@ -151,7 +151,7 @@ public fun <T> Validatable<Collection<T>?>.hasSizeGreaterThan(size: Int): Constr
  * ```
  */
 @JvmName("collectionHasSizeGreaterThanOrEqualTo")
-public fun <T> Validatable<Collection<T>?>.hasSizeGreaterThanOrEqualTo(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Collection<T>?, MetadataType>.hasSizeGreaterThanOrEqualTo(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size >= size } otherwise { "The number of items must be greater than or equal to $size" }
 
 /**
@@ -168,5 +168,5 @@ public fun <T> Validatable<Collection<T>?>.hasSizeGreaterThanOrEqualTo(size: Int
  * ```
  */
 @JvmName("collectionHasSizeBetween")
-public fun <T> Validatable<Collection<T>?>.hasSizeBetween(range: IntRange): Constraint =
+public fun <T, MetadataType> GenericValidatable<Collection<T>?, MetadataType>.hasSizeBetween(range: IntRange): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size in range } otherwise { "The number of items must be between ${range.first} and ${range.last}" }

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Iterable.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Iterable.kt
@@ -17,10 +17,10 @@
 
 package dev.nesk.akkurate.constraints.builders
 
-import dev.nesk.akkurate.constraints.Constraint
+import dev.nesk.akkurate.constraints.GenericConstraint
 import dev.nesk.akkurate.constraints.constrainIfNotNull
 import dev.nesk.akkurate.constraints.otherwise
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.validatables.GenericValidatable
 import kotlin.jvm.JvmName
 
 /*
@@ -44,7 +44,7 @@ import kotlin.jvm.JvmName
  * ```
  */
 @JvmName("iterableIsContaining")
-public fun <T> Validatable<Iterable<T>?>.isContaining(element: T): Constraint =
+public fun <T, MetadataType> GenericValidatable<Iterable<T>?, MetadataType>.isContaining(element: T): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.contains(element) } otherwise { "Must contain \"$element\"" }
 
 /**
@@ -59,7 +59,7 @@ public fun <T> Validatable<Iterable<T>?>.isContaining(element: T): Constraint =
  * ```
  */
 @JvmName("iterableIsNotContaining")
-public fun <T> Validatable<Iterable<T>?>.isNotContaining(element: T): Constraint =
+public fun <T, MetadataType> GenericValidatable<Iterable<T>?, MetadataType>.isNotContaining(element: T): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.contains(element) } otherwise { "Must not contain \"$element\"" }
 
 /**
@@ -73,5 +73,5 @@ public fun <T> Validatable<Iterable<T>?>.isNotContaining(element: T): Constraint
  * validate(listOf('a', 'b', 'c', 'a')) // Failure (message: Must contain unique elements)
  * ```
  */
-public fun <T> Validatable<Iterable<T>?>.hasNoDuplicates(): Constraint =
+public fun <T, MetadataType> GenericValidatable<Iterable<T>?, MetadataType>.hasNoDuplicates(): GenericConstraint<MetadataType> =
     constrainIfNotNull { array -> array.toSet().size == array.count() } otherwise { "Must contain unique elements" }

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Map.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Map.kt
@@ -17,10 +17,10 @@
 
 package dev.nesk.akkurate.constraints.builders
 
-import dev.nesk.akkurate.constraints.Constraint
+import dev.nesk.akkurate.constraints.GenericConstraint
 import dev.nesk.akkurate.constraints.constrainIfNotNull
 import dev.nesk.akkurate.constraints.otherwise
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.validatables.GenericValidatable
 import kotlin.jvm.JvmName
 
 /*
@@ -44,7 +44,7 @@ import kotlin.jvm.JvmName
  * ```
  */
 @JvmName("mapIsEmpty")
-public fun <T> Validatable<Map<*, T>?>.isEmpty(): Constraint =
+public fun <T, MetadataType> GenericValidatable<Map<*, T>?, MetadataType>.isEmpty(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isEmpty() } otherwise { "Must be empty" }
 
 /**
@@ -59,7 +59,7 @@ public fun <T> Validatable<Map<*, T>?>.isEmpty(): Constraint =
  * ```
  */
 @JvmName("mapIsNotEmpty")
-public fun <T> Validatable<Map<*, T>?>.isNotEmpty(): Constraint =
+public fun <T, MetadataType> GenericValidatable<Map<*, T>?, MetadataType>.isNotEmpty(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isNotEmpty() } otherwise { "Must not be empty" }
 
 /**
@@ -74,7 +74,7 @@ public fun <T> Validatable<Map<*, T>?>.isNotEmpty(): Constraint =
  * ```
  */
 @JvmName("mapHasSizeEqualTo")
-public fun <T> Validatable<Map<*, T>?>.hasSizeEqualTo(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Map<*, T>?, MetadataType>.hasSizeEqualTo(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size == size } otherwise { "The number of items must be equal to $size" }
 
 /**
@@ -89,7 +89,7 @@ public fun <T> Validatable<Map<*, T>?>.hasSizeEqualTo(size: Int): Constraint =
  * ```
  */
 @JvmName("mapHasSizeNotEqualTo")
-public fun <T> Validatable<Map<*, T>?>.hasSizeNotEqualTo(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Map<*, T>?, MetadataType>.hasSizeNotEqualTo(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size != size } otherwise { "The number of items must be different from $size" }
 
 /**
@@ -104,7 +104,7 @@ public fun <T> Validatable<Map<*, T>?>.hasSizeNotEqualTo(size: Int): Constraint 
  * ```
  */
 @JvmName("mapHasSizeLowerThan")
-public fun <T> Validatable<Map<*, T>?>.hasSizeLowerThan(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Map<*, T>?, MetadataType>.hasSizeLowerThan(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size < size } otherwise { "The number of items must be lower than $size" }
 
 /**
@@ -120,7 +120,7 @@ public fun <T> Validatable<Map<*, T>?>.hasSizeLowerThan(size: Int): Constraint =
  * ```
  */
 @JvmName("mapHasSizeLowerThanOrEqualTo")
-public fun <T> Validatable<Map<*, T>?>.hasSizeLowerThanOrEqualTo(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Map<*, T>?, MetadataType>.hasSizeLowerThanOrEqualTo(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size <= size } otherwise { "The number of items must be lower than or equal to $size" }
 
 /**
@@ -135,7 +135,7 @@ public fun <T> Validatable<Map<*, T>?>.hasSizeLowerThanOrEqualTo(size: Int): Con
  * ```
  */
 @JvmName("mapHasSizeGreaterThan")
-public fun <T> Validatable<Map<*, T>?>.hasSizeGreaterThan(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Map<*, T>?, MetadataType>.hasSizeGreaterThan(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size > size } otherwise { "The number of items must be greater than $size" }
 
 /**
@@ -151,7 +151,7 @@ public fun <T> Validatable<Map<*, T>?>.hasSizeGreaterThan(size: Int): Constraint
  * ```
  */
 @JvmName("mapHasSizeGreaterThanOrEqualTo")
-public fun <T> Validatable<Map<*, T>?>.hasSizeGreaterThanOrEqualTo(size: Int): Constraint =
+public fun <T, MetadataType> GenericValidatable<Map<*, T>?, MetadataType>.hasSizeGreaterThanOrEqualTo(size: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size >= size } otherwise { "The number of items must be greater than or equal to $size" }
 
 /**
@@ -168,7 +168,7 @@ public fun <T> Validatable<Map<*, T>?>.hasSizeGreaterThanOrEqualTo(size: Int): C
  * ```
  */
 @JvmName("mapHasSizeBetween")
-public fun <T> Validatable<Map<*, T>?>.hasSizeBetween(range: IntRange): Constraint =
+public fun <T, MetadataType> GenericValidatable<Map<*, T>?, MetadataType>.hasSizeBetween(range: IntRange): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.size in range } otherwise { "The number of items must be between ${range.first} and ${range.last}" }
 
 /**
@@ -182,7 +182,7 @@ public fun <T> Validatable<Map<*, T>?>.hasSizeBetween(range: IntRange): Constrai
  * validate(emptyMap()) // Failure (message: Must contain key "b")
  * ```
  */
-public fun <K> Validatable<Map<out K, *>?>.isContainingKey(key: K): Constraint =
+public fun <K, MetadataType> GenericValidatable<Map<out K, *>?, MetadataType>.isContainingKey(key: K): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.containsKey(key) } otherwise { "Must contain key \"$key\"" }
 
 /**
@@ -196,7 +196,7 @@ public fun <K> Validatable<Map<out K, *>?>.isContainingKey(key: K): Constraint =
  * validate(mapOf('a' to 1, 'b' to 2, 'c' to 3)) // Failure (message: Must not contain key "b")
  * ```
  */
-public fun <K> Validatable<Map<out K, *>?>.isNotContainingKey(key: K): Constraint =
+public fun <K, MetadataType> GenericValidatable<Map<out K, *>?, MetadataType>.isNotContainingKey(key: K): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.containsKey(key) } otherwise { "Must not contain key \"$key\"" }
 
 /**
@@ -210,7 +210,7 @@ public fun <K> Validatable<Map<out K, *>?>.isNotContainingKey(key: K): Constrain
  * validate(emptyMap()) // Failure (message: Must contain value "2")
  * ```
  */
-public fun <V> Validatable<Map<*, V>?>.isContainingValue(value: V): Constraint =
+public fun <V, MetadataType> GenericValidatable<Map<*, V>?, MetadataType>.isContainingValue(value: V): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.containsValue(value) } otherwise { "Must contain value \"$value\"" }
 
 /**
@@ -224,5 +224,5 @@ public fun <V> Validatable<Map<*, V>?>.isContainingValue(value: V): Constraint =
  * validate(mapOf('a' to 1, 'b' to 2, 'c' to 3)) // Failure (message: Must not contain value "2")
  * ```
  */
-public fun <V> Validatable<Map<*, V>?>.isNotContainingValue(value: V): Constraint =
+public fun <V, MetadataType> GenericValidatable<Map<*, V>?, MetadataType>.isNotContainingValue(value: V): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.containsValue(value) } otherwise { "Must not contain value \"$value\"" }

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Number.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Number.kt
@@ -17,39 +17,39 @@
 
 package dev.nesk.akkurate.constraints.builders
 
-import dev.nesk.akkurate.constraints.Constraint
+import dev.nesk.akkurate.constraints.GenericConstraint
 import dev.nesk.akkurate.constraints.constrainIfNotNull
 import dev.nesk.akkurate.constraints.otherwise
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.validatables.GenericValidatable
 import kotlin.jvm.JvmName
 
 //region isNotNaN
 @JvmName("floatIsNotNaN")
-public fun Validatable<Float?>.isNotNaN(): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.isNotNaN(): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.isNaN() } otherwise { "Must be a valid number" }
 
 @JvmName("doubleIsNotNaN")
-public fun Validatable<Double?>.isNotNaN(): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.isNotNaN(): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.isNaN() } otherwise { "Must be a valid number" }
 //endregion
 
 //region isFinite
 @JvmName("floatIsFinite")
-public fun Validatable<Float?>.isFinite(): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.isFinite(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isFinite() } otherwise { "Must be finite" }
 
 @JvmName("doubleIsFinite")
-public fun Validatable<Double?>.isFinite(): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.isFinite(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isFinite() } otherwise { "Must be finite" }
 //endregion
 
 //region isInfinite
 @JvmName("floatIsInfinite")
-public fun Validatable<Float?>.isInfinite(): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.isInfinite(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isInfinite() } otherwise { "Must be infinite" }
 
 @JvmName("doubleIsInfinite")
-public fun Validatable<Double?>.isInfinite(): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.isInfinite(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isInfinite() } otherwise { "Must be infinite" }
 //endregion
 
@@ -57,23 +57,23 @@ public fun Validatable<Double?>.isInfinite(): Constraint =
 private const val negativeMessage = "Must be negative"
 
 @JvmName("shortIsNegative")
-public fun Validatable<Short?>.isNegative(): Constraint =
+public fun <MetadataType> GenericValidatable<Short?, MetadataType>.isNegative(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < 0 } otherwise { negativeMessage }
 
 @JvmName("intIsNegative")
-public fun Validatable<Int?>.isNegative(): Constraint =
+public fun <MetadataType> GenericValidatable<Int?, MetadataType>.isNegative(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < 0 } otherwise { negativeMessage }
 
 @JvmName("longIsNegative")
-public fun Validatable<Long?>.isNegative(): Constraint =
+public fun <MetadataType> GenericValidatable<Long?, MetadataType>.isNegative(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < 0 } otherwise { negativeMessage }
 
 @JvmName("floatIsNegative")
-public fun Validatable<Float?>.isNegative(): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.isNegative(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < 0 } otherwise { negativeMessage }
 
 @JvmName("doubleIsNegative")
-public fun Validatable<Double?>.isNegative(): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.isNegative(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < 0 } otherwise { negativeMessage }
 //endregion
 
@@ -81,23 +81,23 @@ public fun Validatable<Double?>.isNegative(): Constraint =
 private const val negativeOrZeroMessage = "Must be negative or equal to zero"
 
 @JvmName("shortIsNegativeOrZero")
-public fun Validatable<Short?>.isNegativeOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Short?, MetadataType>.isNegativeOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= 0 } otherwise { negativeOrZeroMessage }
 
 @JvmName("intIsNegativeOrZero")
-public fun Validatable<Int?>.isNegativeOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Int?, MetadataType>.isNegativeOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= 0 } otherwise { negativeOrZeroMessage }
 
 @JvmName("longIsNegativeOrZero")
-public fun Validatable<Long?>.isNegativeOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Long?, MetadataType>.isNegativeOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= 0 } otherwise { negativeOrZeroMessage }
 
 @JvmName("floatIsNegativeOrZero")
-public fun Validatable<Float?>.isNegativeOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.isNegativeOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= 0 } otherwise { negativeOrZeroMessage }
 
 @JvmName("doubleIsNegativeOrZero")
-public fun Validatable<Double?>.isNegativeOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.isNegativeOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= 0 } otherwise { negativeOrZeroMessage }
 //endregion
 
@@ -105,23 +105,23 @@ public fun Validatable<Double?>.isNegativeOrZero(): Constraint =
 private const val positiveMessage = "Must be positive"
 
 @JvmName("shortIsPositive")
-public fun Validatable<Short?>.isPositive(): Constraint =
+public fun <MetadataType> GenericValidatable<Short?, MetadataType>.isPositive(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > 0 } otherwise { positiveMessage }
 
 @JvmName("intIsPositive")
-public fun Validatable<Int?>.isPositive(): Constraint =
+public fun <MetadataType> GenericValidatable<Int?, MetadataType>.isPositive(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > 0 } otherwise { positiveMessage }
 
 @JvmName("longIsPositive")
-public fun Validatable<Long?>.isPositive(): Constraint =
+public fun <MetadataType> GenericValidatable<Long?, MetadataType>.isPositive(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > 0 } otherwise { positiveMessage }
 
 @JvmName("floatIsPositive")
-public fun Validatable<Float?>.isPositive(): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.isPositive(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > 0 } otherwise { positiveMessage }
 
 @JvmName("doubleIsPositive")
-public fun Validatable<Double?>.isPositive(): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.isPositive(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > 0 } otherwise { positiveMessage }
 //endregion
 
@@ -129,129 +129,129 @@ public fun Validatable<Double?>.isPositive(): Constraint =
 private const val positiveOrZeroMessage = "Must be positive or equal to zero"
 
 @JvmName("shortIsPositiveOrZero")
-public fun Validatable<Short?>.isPositiveOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Short?, MetadataType>.isPositiveOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= 0 } otherwise { positiveOrZeroMessage }
 
 @JvmName("intIsPositiveOrZero")
-public fun Validatable<Int?>.isPositiveOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Int?, MetadataType>.isPositiveOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= 0 } otherwise { positiveOrZeroMessage }
 
 @JvmName("longIsPositiveOrZero")
-public fun Validatable<Long?>.isPositiveOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Long?, MetadataType>.isPositiveOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= 0 } otherwise { positiveOrZeroMessage }
 
 @JvmName("floatIsPositiveOrZero")
-public fun Validatable<Float?>.isPositiveOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.isPositiveOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= 0 } otherwise { positiveOrZeroMessage }
 
 @JvmName("doubleIsPositiveOrZero")
-public fun Validatable<Double?>.isPositiveOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.isPositiveOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= 0 } otherwise { positiveOrZeroMessage }
 //endregion
 
 //region isLowerThan
-private infix fun Constraint.otherwiseLowerThan(value: Number) = otherwise { "Must be lower than $value" }
+private infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseLowerThan(value: Number) = otherwise { "Must be lower than $value" }
 
-public fun Validatable<Short?>.isLowerThan(value: Short): Constraint =
+public fun <MetadataType> GenericValidatable<Short?, MetadataType>.isLowerThan(value: Short): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < value } otherwiseLowerThan value
 
-public fun Validatable<Int?>.isLowerThan(value: Int): Constraint =
+public fun <MetadataType> GenericValidatable<Int?, MetadataType>.isLowerThan(value: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < value } otherwiseLowerThan value
 
-public fun Validatable<Long?>.isLowerThan(value: Long): Constraint =
+public fun <MetadataType> GenericValidatable<Long?, MetadataType>.isLowerThan(value: Long): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < value } otherwiseLowerThan value
 
-public fun Validatable<Float?>.isLowerThan(value: Float): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.isLowerThan(value: Float): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < value } otherwiseLowerThan value
 
-public fun Validatable<Double?>.isLowerThan(value: Double): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.isLowerThan(value: Double): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < value } otherwiseLowerThan value
 //endregion
 
 //region isLowerThanOrEqualTo
-private infix fun Constraint.otherwiseLowerThanOrEqualTo(value: Number) = otherwise { "Must be lower than or equal to $value" }
+private infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseLowerThanOrEqualTo(value: Number) = otherwise { "Must be lower than or equal to $value" }
 
-public fun Validatable<Short?>.isLowerThanOrEqualTo(value: Short): Constraint =
+public fun <MetadataType> GenericValidatable<Short?, MetadataType>.isLowerThanOrEqualTo(value: Short): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= value } otherwiseLowerThanOrEqualTo value
 
-public fun Validatable<Int?>.isLowerThanOrEqualTo(value: Int): Constraint =
+public fun <MetadataType> GenericValidatable<Int?, MetadataType>.isLowerThanOrEqualTo(value: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= value } otherwiseLowerThanOrEqualTo value
 
-public fun Validatable<Long?>.isLowerThanOrEqualTo(value: Long): Constraint =
+public fun <MetadataType> GenericValidatable<Long?, MetadataType>.isLowerThanOrEqualTo(value: Long): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= value } otherwiseLowerThanOrEqualTo value
 
-public fun Validatable<Float?>.isLowerThanOrEqualTo(value: Float): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.isLowerThanOrEqualTo(value: Float): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= value } otherwiseLowerThanOrEqualTo value
 
-public fun Validatable<Double?>.isLowerThanOrEqualTo(value: Double): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.isLowerThanOrEqualTo(value: Double): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= value } otherwiseLowerThanOrEqualTo value
 //endregion
 
 //region isGreaterThan
-private infix fun Constraint.otherwiseGreaterThan(value: Number) = otherwise { "Must be greater than $value" }
+private infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseGreaterThan(value: Number) = otherwise { "Must be greater than $value" }
 
-public fun Validatable<Short?>.isGreaterThan(value: Short): Constraint =
+public fun <MetadataType> GenericValidatable<Short?, MetadataType>.isGreaterThan(value: Short): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > value } otherwiseGreaterThan value
 
-public fun Validatable<Int?>.isGreaterThan(value: Int): Constraint =
+public fun <MetadataType> GenericValidatable<Int?, MetadataType>.isGreaterThan(value: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > value } otherwiseGreaterThan value
 
-public fun Validatable<Long?>.isGreaterThan(value: Long): Constraint =
+public fun <MetadataType> GenericValidatable<Long?, MetadataType>.isGreaterThan(value: Long): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > value } otherwiseGreaterThan value
 
-public fun Validatable<Float?>.isGreaterThan(value: Float): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.isGreaterThan(value: Float): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > value } otherwiseGreaterThan value
 
-public fun Validatable<Double?>.isGreaterThan(value: Double): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.isGreaterThan(value: Double): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > value } otherwiseGreaterThan value
 //endregion
 
 //region isGreaterThanOrEqualTo
-private infix fun Constraint.otherwiseGreaterThanOrEqualTo(value: Number) = otherwise { "Must be greater than or equal to $value" }
+private infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseGreaterThanOrEqualTo(value: Number) = otherwise { "Must be greater than or equal to $value" }
 
-public fun Validatable<Short?>.isGreaterThanOrEqualTo(value: Short): Constraint =
+public fun <MetadataType> GenericValidatable<Short?, MetadataType>.isGreaterThanOrEqualTo(value: Short): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= value } otherwiseGreaterThanOrEqualTo value
 
-public fun Validatable<Int?>.isGreaterThanOrEqualTo(value: Int): Constraint =
+public fun <MetadataType> GenericValidatable<Int?, MetadataType>.isGreaterThanOrEqualTo(value: Int): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= value } otherwiseGreaterThanOrEqualTo value
 
-public fun Validatable<Long?>.isGreaterThanOrEqualTo(value: Long): Constraint =
+public fun <MetadataType> GenericValidatable<Long?, MetadataType>.isGreaterThanOrEqualTo(value: Long): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= value } otherwiseGreaterThanOrEqualTo value
 
-public fun Validatable<Float?>.isGreaterThanOrEqualTo(value: Float): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.isGreaterThanOrEqualTo(value: Float): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= value } otherwiseGreaterThanOrEqualTo value
 
-public fun Validatable<Double?>.isGreaterThanOrEqualTo(value: Double): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.isGreaterThanOrEqualTo(value: Double): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= value } otherwiseGreaterThanOrEqualTo value
 //endregion
 
 //region isBetween
 @JvmName("shortIsBetween")
-public fun Validatable<Short?>.isBetween(range: IntRange): Constraint =
+public fun <MetadataType> GenericValidatable<Short?, MetadataType>.isBetween(range: IntRange): GenericConstraint<MetadataType> =
     constrainIfNotNull { it in range } otherwise { "Must be between ${range.first} and ${range.last} (inclusive)" }
 
-public fun Validatable<Int?>.isBetween(range: IntRange): Constraint =
+public fun <MetadataType> GenericValidatable<Int?, MetadataType>.isBetween(range: IntRange): GenericConstraint<MetadataType> =
     constrainIfNotNull { it in range } otherwise { "Must be between ${range.first} and ${range.last} (inclusive)" }
 
-public fun Validatable<Long?>.isBetween(range: LongRange): Constraint =
+public fun <MetadataType> GenericValidatable<Long?, MetadataType>.isBetween(range: LongRange): GenericConstraint<MetadataType> =
     constrainIfNotNull { it in range } otherwise { "Must be between ${range.first} and ${range.last} (inclusive)" }
 
 @JvmName("closedFloatIsBetween")
-public fun Validatable<Float?>.isBetween(range: ClosedFloatingPointRange<Float>): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.isBetween(range: ClosedFloatingPointRange<Float>): GenericConstraint<MetadataType> =
     constrainIfNotNull { it in range } otherwise { "Must be between ${range.start} and ${range.endInclusive} (inclusive)" }
 
 @JvmName("closedDoubleIsBetween")
-public fun Validatable<Double?>.isBetween(range: ClosedFloatingPointRange<Double>): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.isBetween(range: ClosedFloatingPointRange<Double>): GenericConstraint<MetadataType> =
     constrainIfNotNull { it in range } otherwise { "Must be between ${range.start} and ${range.endInclusive} (inclusive)" }
 
 @OptIn(ExperimentalStdlibApi::class)
 @JvmName("openFloatIsBetween")
-public fun Validatable<Float?>.isBetween(range: OpenEndRange<Float>): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.isBetween(range: OpenEndRange<Float>): GenericConstraint<MetadataType> =
     constrainIfNotNull { it in range } otherwise { "Must be between ${range.start} and ${range.endExclusive} (exclusive)" }
 
 @OptIn(ExperimentalStdlibApi::class)
 @JvmName("openDoubleIsBetween")
-public fun Validatable<Double?>.isBetween(range: OpenEndRange<Double>): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.isBetween(range: OpenEndRange<Double>): GenericConstraint<MetadataType> =
     constrainIfNotNull { it in range } otherwise { "Must be between ${range.start} and ${range.endExclusive} (exclusive)" }
 //endregion
 
@@ -262,10 +262,10 @@ private fun requireCountGreaterThanZero(count: Int) {
     require(count > 0) { "'count' cannot be lower than 1" }
 }
 
-private fun Validatable<Number?>.constrainDigitCount(
+private fun <MetadataType> GenericValidatable<Number?, MetadataType>.constrainDigitCount(
     runDecimalChecks: Boolean,
     block: (integralCount: Int, fractionalCount: Int?) -> Boolean,
-): Constraint {
+): GenericConstraint<MetadataType> {
     return constrainIfNotNull {
         if (runDecimalChecks) {
             val floatValue = it.toFloat()
@@ -277,44 +277,44 @@ private fun Validatable<Number?>.constrainDigitCount(
     }
 }
 
-private fun Validatable<Number?>.constrainIntegralPart(count: Int, runDecimalChecks: Boolean): Constraint {
+private fun <MetadataType> GenericValidatable<Number?, MetadataType>.constrainIntegralPart(count: Int, runDecimalChecks: Boolean): GenericConstraint<MetadataType> {
     requireCountGreaterThanZero(count)
     return constrainDigitCount(runDecimalChecks) { integralCount, _ ->
         integralCount == count
     }
 }
 
-internal fun Validatable<Number?>.constrainDecimalPart(count: Int): Constraint {
+internal fun <MetadataType> GenericValidatable<Number?, MetadataType>.constrainDecimalPart(count: Int): GenericConstraint<MetadataType> {
     requireCountGreaterThanZero(count)
     return constrainDigitCount(runDecimalChecks = true) { _, fractionalCount ->
         if (fractionalCount == null) false else fractionalCount == count
     }
 }
 
-private infix fun Constraint.otherwiseIntegralCountEqualTo(count: Int) = otherwise { "Must contain $count integral digits" }
-internal infix fun Constraint.otherwiseFractionalCountEqualTo(count: Int) = otherwise { "Must contain $count fractional digits" }
+private infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseIntegralCountEqualTo(count: Int) = otherwise { "Must contain $count integral digits" }
+internal infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseFractionalCountEqualTo(count: Int) = otherwise { "Must contain $count fractional digits" }
 
 @JvmName("shortHasIntegralCountEqualTo")
-public fun Validatable<Short?>.hasIntegralCountEqualTo(count: Int): Constraint =
+public fun <MetadataType> GenericValidatable<Short?, MetadataType>.hasIntegralCountEqualTo(count: Int): GenericConstraint<MetadataType> =
     constrainIntegralPart(count, runDecimalChecks = false) otherwiseIntegralCountEqualTo count
 
 @JvmName("intHasIntegralCountEqualTo")
-public fun Validatable<Int?>.hasIntegralCountEqualTo(count: Int): Constraint =
+public fun <MetadataType> GenericValidatable<Int?, MetadataType>.hasIntegralCountEqualTo(count: Int): GenericConstraint<MetadataType> =
     constrainIntegralPart(count, runDecimalChecks = false) otherwiseIntegralCountEqualTo count
 
 @JvmName("longHasIntegralCountEqualTo")
-public fun Validatable<Long?>.hasIntegralCountEqualTo(count: Int): Constraint =
+public fun <MetadataType> GenericValidatable<Long?, MetadataType>.hasIntegralCountEqualTo(count: Int): GenericConstraint<MetadataType> =
     constrainIntegralPart(count, runDecimalChecks = false) otherwiseIntegralCountEqualTo count
 
 @JvmName("floatHasIntegralCountEqualTo")
-public fun Validatable<Float?>.hasIntegralCountEqualTo(count: Int): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.hasIntegralCountEqualTo(count: Int): GenericConstraint<MetadataType> =
     constrainIntegralPart(count, runDecimalChecks = true) otherwiseIntegralCountEqualTo count
 
 @JvmName("doubleHasIntegralCountEqualTo")
-public fun Validatable<Double?>.hasIntegralCountEqualTo(count: Int): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.hasIntegralCountEqualTo(count: Int): GenericConstraint<MetadataType> =
     constrainIntegralPart(count, runDecimalChecks = true) otherwiseIntegralCountEqualTo count
 
 @JvmName("doubleHasFractionalCountEqualTo")
-public fun Validatable<Double?>.hasFractionalCountEqualTo(count: Int): Constraint =
+public fun <MetadataType> GenericValidatable<Double?, MetadataType>.hasFractionalCountEqualTo(count: Int): GenericConstraint<MetadataType> =
     constrainDecimalPart(count) otherwiseFractionalCountEqualTo count
 //endregion

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Time.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/Time.kt
@@ -17,10 +17,10 @@
 
 package dev.nesk.akkurate.constraints.builders
 
-import dev.nesk.akkurate.constraints.Constraint
+import dev.nesk.akkurate.constraints.GenericConstraint
 import dev.nesk.akkurate.constraints.constrainIfNotNull
 import dev.nesk.akkurate.constraints.otherwise
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.validatables.GenericValidatable
 import kotlin.time.Duration
 
 /**
@@ -35,7 +35,7 @@ import kotlin.time.Duration
  * validate(1.seconds) // Failure (message: Must be negative)
  * ```
  */
-public fun Validatable<Duration?>.isNegative(): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isNegative(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isNegative() && it != Duration.ZERO } otherwise { "Must be negative" }
 
 /**
@@ -50,7 +50,7 @@ public fun Validatable<Duration?>.isNegative(): Constraint =
  * validate(1.seconds) // Failure (message: Must be negative or equal to zero)
  * ```
  */
-public fun Validatable<Duration?>.isNegativeOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isNegativeOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isNegative() || it == Duration.ZERO } otherwise { "Must be negative or equal to zero" }
 
 /**
@@ -65,7 +65,7 @@ public fun Validatable<Duration?>.isNegativeOrZero(): Constraint =
  * validate((-1).seconds) // Failure (message: Must be positive)
  * ```
  */
-public fun Validatable<Duration?>.isPositive(): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isPositive(): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.isNegative() && it != Duration.ZERO } otherwise { "Must be positive" }
 
 /**
@@ -80,7 +80,7 @@ public fun Validatable<Duration?>.isPositive(): Constraint =
  * validate((-1).seconds) // Failure (message: Must be positive or equal to zero)
  * ```
  */
-public fun Validatable<Duration?>.isPositiveOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isPositiveOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.isNegative() || it == Duration.ZERO } otherwise { "Must be positive or equal to zero" }
 
 /**
@@ -95,7 +95,7 @@ public fun Validatable<Duration?>.isPositiveOrZero(): Constraint =
  * validate(1.seconds) // Failure (message: Must be lower than 0s)
  * ```
  */
-public fun Validatable<Duration?>.isLowerThan(value: Duration): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isLowerThan(value: Duration): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < value } otherwise { "Must be lower than $value" }
 
 /**
@@ -110,7 +110,7 @@ public fun Validatable<Duration?>.isLowerThan(value: Duration): Constraint =
  * validate(1.seconds) // Failure (message: Must be lower than or equal to 0s)
  * ```
  */
-public fun Validatable<Duration?>.isLowerThanOrEqualTo(value: Duration): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isLowerThanOrEqualTo(value: Duration): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= value } otherwise { "Must be lower than or equal to $value" }
 
 /**
@@ -125,7 +125,7 @@ public fun Validatable<Duration?>.isLowerThanOrEqualTo(value: Duration): Constra
  * validate((-1).seconds) // Failure (message: Must be greater than 0s)
  * ```
  */
-public fun Validatable<Duration?>.isGreaterThan(value: Duration): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isGreaterThan(value: Duration): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > value } otherwise { "Must be greater than $value" }
 
 /**
@@ -140,7 +140,7 @@ public fun Validatable<Duration?>.isGreaterThan(value: Duration): Constraint =
  * validate((-1).seconds) // Failure (message: Must be greater than or equal to 0s)
  * ```
  */
-public fun Validatable<Duration?>.isGreaterThanOrEqualTo(value: Duration): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isGreaterThanOrEqualTo(value: Duration): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= value } otherwise { "Must be greater than or equal to $value" }
 
 //region isBetween
@@ -159,7 +159,7 @@ public fun Validatable<Duration?>.isGreaterThanOrEqualTo(value: Duration): Const
  * validate(15.seconds) // Failure (message: Must be between 0s and 10s (inclusive))
  * ```
  */
-public fun Validatable<Duration?>.isBetween(range: ClosedRange<Duration>): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isBetween(range: ClosedRange<Duration>): GenericConstraint<MetadataType> =
     constrainIfNotNull { it in range } otherwise { "Must be between ${range.start} and ${range.endInclusive} (inclusive)" }
 
 /**
@@ -177,6 +177,6 @@ public fun Validatable<Duration?>.isBetween(range: ClosedRange<Duration>): Const
  * validate(15.seconds) // Failure (message: Must be between 0s and 10s (exclusive))
  * ```
  */
-public fun Validatable<Duration?>.isBetween(range: OpenEndRange<Duration>): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isBetween(range: OpenEndRange<Duration>): GenericConstraint<MetadataType> =
     constrainIfNotNull { it in range } otherwise { "Must be between ${range.start} and ${range.endExclusive} (exclusive)" }
 //endregion

--- a/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/validatables/ValidatableCompound.kt
+++ b/akkurate-core/src/commonMain/kotlin/dev/nesk/akkurate/validatables/ValidatableCompound.kt
@@ -29,18 +29,18 @@ package dev.nesk.akkurate.validatables
 
     To ease development, the first release will make parentheses mandatory.
  */
-public class ValidatableCompound<T> internal constructor(validatables: List<Validatable<T>>) {
-    public val validatables: List<Validatable<T>> = validatables.distinctBy { it.path() }
+public class ValidatableCompound<T, MetadataType> internal constructor(validatables: List<GenericValidatable<T, MetadataType>>) {
+    public val validatables: List<GenericValidatable<T, MetadataType>> = validatables.distinctBy { it.path() }
 
-    public infix fun and(other: Validatable<T>): ValidatableCompound<T> = ValidatableCompound(validatables + setOf(other))
-    public infix fun and(other: ValidatableCompound<T>): ValidatableCompound<T> = ValidatableCompound(validatables + other.validatables)
+    public infix fun and(other: GenericValidatable<T, MetadataType>): ValidatableCompound<T, MetadataType> = ValidatableCompound(validatables + setOf(other))
+    public infix fun and(other: ValidatableCompound<T, MetadataType>): ValidatableCompound<T, MetadataType> = ValidatableCompound(validatables + other.validatables)
 
     // TODO: Convert to extension function (breaking change) once JetBrains fixes imports: https://youtrack.jetbrains.com/issue/KTIJ-22147
-    public inline operator fun invoke(block: Validatable<T>.() -> Unit): Unit = validatables.forEach { it.block() }
+    public inline operator fun invoke(block: GenericValidatable<T, MetadataType>.() -> Unit): Unit = validatables.forEach { it.block() }
 }
 
-public infix fun <T> Validatable<T>.and(other: Validatable<T>): ValidatableCompound<T> = ValidatableCompound(listOf(this, other))
-public infix fun <T> Validatable<T>.and(other: ValidatableCompound<T>): ValidatableCompound<T> = ValidatableCompound(listOf(this) + other.validatables)
+public infix fun <T, MetadataType> GenericValidatable<T, MetadataType>.and(other: GenericValidatable<T, MetadataType>): ValidatableCompound<T, MetadataType> = ValidatableCompound(listOf(this, other))
+public infix fun <T, MetadataType> GenericValidatable<T, MetadataType>.and(other: ValidatableCompound<T, MetadataType>): ValidatableCompound<T, MetadataType> = ValidatableCompound(listOf(this) + other.validatables)
 
 // TODO: find a solution to improve type combinations
 //infix fun <T1, T2> ValidatableCompound<T1>.and(other: Validatable<T2>): ValidatableCompound<Any?> = TODO()

--- a/akkurate-core/src/commonTest/kotlin/dev/nesk/akkurate/ValidationResultTest.kt
+++ b/akkurate-core/src/commonTest/kotlin/dev/nesk/akkurate/ValidationResultTest.kt
@@ -46,7 +46,7 @@ class ValidationResultTest {
         val failure = ValidationResult.Failure(violations)
         // Act & Assert
         val exception = assertFailsWith<ValidationResult.Exception> { failure.orThrow() }
-        assertSame(violations, exception.violations)
+        assertEquals(violations, exception.violations)
     }
 
     @Test

--- a/akkurate-core/src/commonTest/kotlin/dev/nesk/akkurate/ValidatorTest.kt
+++ b/akkurate-core/src/commonTest/kotlin/dev/nesk/akkurate/ValidatorTest.kt
@@ -21,6 +21,7 @@ import dev.nesk.akkurate.constraints.ConstraintViolation
 import dev.nesk.akkurate.constraints.constrain
 import dev.nesk.akkurate.constraints.otherwise
 import dev.nesk.akkurate.constraints.withPath
+import dev.nesk.akkurate.validatables.DefaultMetadataType
 import dev.nesk.akkurate.validatables.validatableOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
@@ -57,7 +58,7 @@ class ValidatorTest {
         // Act
         val result = validate(null)
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertEquals(expectedViolations, result.violations, "The result contains the corresponding violations")
     }
 
@@ -83,7 +84,7 @@ class ValidatorTest {
         // Act
         val result = validate(Context(), null)
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertEquals(expectedViolations, result.violations, "The result contains the corresponding violations")
     }
 
@@ -109,7 +110,7 @@ class ValidatorTest {
         // Act
         val result = validate(null)
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertEquals(expectedViolations, result.violations, "The result contains the corresponding violations")
     }
 
@@ -135,7 +136,7 @@ class ValidatorTest {
         // Act
         val result = validate(Context(), null)
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertEquals(expectedViolations, result.violations, "The result contains the corresponding violations")
     }
 
@@ -146,7 +147,7 @@ class ValidatorTest {
             validatableOf(Value::name).constrain { false }
         }
         val result = validate(Value())
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertEquals(listOf("foo", "bar", "name"), result.violations.single().path)
     }
 
@@ -157,7 +158,7 @@ class ValidatorTest {
             constrain { false }
         }
         val result = validate(null)
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertEquals("default", result.violations.single().message)
     }
 
@@ -174,7 +175,7 @@ class ValidatorTest {
         val result = validate(null)
 
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertEquals("first message", result.violations.single().message)
     }
 
@@ -191,7 +192,7 @@ class ValidatorTest {
         val result = validate(null)
 
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertEquals(2, result.violations.size)
         assertContentEquals(listOf("first message", "second message"), result.violations.map { it.message })
     }
@@ -221,7 +222,7 @@ class ValidatorTest {
         val result = validate1(First(Second(Third())))
 
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertContentEquals(expectedViolations, result.violations.toList(), "All the constraints violations are reported")
     }
 
@@ -250,7 +251,7 @@ class ValidatorTest {
         val result = validate1(Context(), First(Second(Third())))
 
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertContentEquals(expectedViolations, result.violations.toList(), "All the constraints violations are reported")
     }
 
@@ -279,7 +280,7 @@ class ValidatorTest {
         val result = validate1(First(Second(Third())))
 
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertContentEquals(expectedViolations, result.violations.toList(), "All the constraints violations are reported")
     }
 
@@ -308,7 +309,7 @@ class ValidatorTest {
         val result = validate1(Context(), First(Second(Third())))
 
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertContentEquals(expectedViolations, result.violations.toList(), "All the constraints violations are reported")
     }
 }

--- a/akkurate-core/src/commonTest/kotlin/dev/nesk/akkurate/constraints/ConstraintRegistryTest.kt
+++ b/akkurate-core/src/commonTest/kotlin/dev/nesk/akkurate/constraints/ConstraintRegistryTest.kt
@@ -21,6 +21,7 @@ import dev.nesk.akkurate.Configuration
 import dev.nesk.akkurate.ValidationResult
 import dev.nesk.akkurate._test.Validatable
 import dev.nesk.akkurate.test.Validatable
+import dev.nesk.akkurate.validatables.DefaultMetadataType
 import kotlin.test.*
 
 class ConstraintRegistryTest {
@@ -104,7 +105,7 @@ class ConstraintRegistryTest {
             it.register(constraint3)
         }
         // Assert
-        assertIs<ValidationResult.Failure>(result)
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result)
         assertContentEquals(listOf("message 2", "message 3"), result.violations.map { it.message })
     }
 
@@ -116,7 +117,7 @@ class ConstraintRegistryTest {
         // Act
         val result = runWithConstraintRegistry(null, config) { it.register(constraint) }
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertEquals(listOf("foo", "bar", "baz"), result.violations.single().path)
     }
 
@@ -128,7 +129,7 @@ class ConstraintRegistryTest {
         // Act
         val result = runWithConstraintRegistry(null, config) { it.register(constraint) }
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertEquals("default", result.violations.single().message)
     }
 
@@ -145,7 +146,7 @@ class ConstraintRegistryTest {
             it.register(constraint2)
         }
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertEquals("first message", result.violations.single().message)
     }
 
@@ -162,7 +163,7 @@ class ConstraintRegistryTest {
             it.register(constraint2)
         }
         // Assert
-        assertIs<ValidationResult.Failure>(result, "The result is a failure")
+        assertIs<ValidationResult.Failure<DefaultMetadataType>>(result, "The result is a failure")
         assertEquals(2, result.violations.size)
         assertContentEquals(listOf("first message", "second message"), result.violations.map { it.message })
     }

--- a/akkurate-core/src/commonTest/kotlin/dev/nesk/akkurate/constraints/ConstraintTest.kt
+++ b/akkurate-core/src/commonTest/kotlin/dev/nesk/akkurate/constraints/ConstraintTest.kt
@@ -88,6 +88,12 @@ class ConstraintTest {
     }
 
     @Test
+    fun calling__withMetadata_updates_the_metadata() {
+        val constraint = ConstraintBuilder(true) withMetadata { mapOf("foo" to "bar") }
+        assertEquals(mapOf("foo" to "bar"), constraint.metadata)
+    }
+
+    @Test
     fun calling__withPath__with_a_lambda_updates_the_path_if_the_constraint_is_not_satisfied() {
         // Arrange
         val validatable = Validatable(null, "foo")

--- a/akkurate-core/src/jvmMain/kotlin/dev/nesk/akkurate/accessors/Instant.kt
+++ b/akkurate-core/src/jvmMain/kotlin/dev/nesk/akkurate/accessors/Instant.kt
@@ -17,9 +17,9 @@
 
 package dev.nesk.akkurate.accessors
 
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.validatables.GenericValidatable
 import dev.nesk.akkurate.validatables.validatableOf
 import java.time.Instant
 
-public val Validatable<Instant>.epochSecond: Validatable<Long> get() = validatableOf(Instant::getEpochSecond)
-public val Validatable<Instant>.nanos: Validatable<Int> get() = validatableOf(Instant::getNano)
+public val <MetadataType> GenericValidatable<Instant, MetadataType>.epochSecond: GenericValidatable<Long, MetadataType> get() = validatableOf(Instant::getEpochSecond)
+public val <MetadataType> GenericValidatable<Instant, MetadataType>.nanos: GenericValidatable<Int, MetadataType> get() = validatableOf(Instant::getNano)

--- a/akkurate-core/src/jvmMain/kotlin/dev/nesk/akkurate/constraints/builders/Float.kt
+++ b/akkurate-core/src/jvmMain/kotlin/dev/nesk/akkurate/constraints/builders/Float.kt
@@ -17,12 +17,12 @@
 
 package dev.nesk.akkurate.constraints.builders
 
-import dev.nesk.akkurate.constraints.Constraint
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.constraints.GenericConstraint
+import dev.nesk.akkurate.validatables.GenericValidatable
 
 // Keep this constraint only available to the JVM target to avoid potential issues.
 // For example, the JS target fails to properly determine the fractional count of a Float.
 // We'll see later to make this constraint available to all targets.
 @JvmName("floatHasFractionalCountEqualTo")
-public fun Validatable<Float?>.hasFractionalCountEqualTo(count: Int): Constraint =
+public fun <MetadataType> GenericValidatable<Float?, MetadataType>.hasFractionalCountEqualTo(count: Int): GenericConstraint<MetadataType> =
     constrainDecimalPart(count) otherwiseFractionalCountEqualTo count

--- a/akkurate-core/src/jvmMain/kotlin/dev/nesk/akkurate/constraints/builders/TemporalAccessor.kt
+++ b/akkurate-core/src/jvmMain/kotlin/dev/nesk/akkurate/constraints/builders/TemporalAccessor.kt
@@ -17,10 +17,10 @@
 
 package dev.nesk.akkurate.constraints.builders
 
-import dev.nesk.akkurate.constraints.Constraint
+import dev.nesk.akkurate.constraints.GenericConstraint
 import dev.nesk.akkurate.constraints.constrainIfNotNull
 import dev.nesk.akkurate.constraints.otherwise
-import dev.nesk.akkurate.validatables.Validatable
+import dev.nesk.akkurate.validatables.GenericValidatable
 import java.time.*
 
 /**
@@ -37,19 +37,19 @@ private val currentZonedDateTime get() = ZonedDateTime.now(clock)
 private const val pastMessage = "Must be in the past"
 
 @JvmName("instantIsInPast")
-public fun Validatable<Instant?>.isInPast(): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isInPast(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < currentInstant } otherwise { pastMessage }
 
 @JvmName("localDateIsInPast")
-public fun Validatable<LocalDate?>.isInPast(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isInPast(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < currentLocalDate } otherwise { pastMessage }
 
 @JvmName("localDateTimeIsInPast")
-public fun Validatable<LocalDateTime?>.isInPast(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isInPast(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < currentLocalDateTime } otherwise { pastMessage }
 
 @JvmName("zonedDateTimeIsInPast")
-public fun Validatable<ZonedDateTime?>.isInPast(): Constraint =
+public fun <MetadataType> GenericValidatable<ZonedDateTime?, MetadataType>.isInPast(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < currentZonedDateTime } otherwise { pastMessage }
 //endregion
 
@@ -57,19 +57,19 @@ public fun Validatable<ZonedDateTime?>.isInPast(): Constraint =
 private const val pastOrPresentMessage = "Must be in the past or present"
 
 @JvmName("instantIsInPastOrIsPresent")
-public fun Validatable<Instant?>.isInPastOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isInPastOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= currentInstant } otherwise { pastOrPresentMessage }
 
 @JvmName("localDateIsInPastOrIsPresent")
-public fun Validatable<LocalDate?>.isInPastOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isInPastOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= currentLocalDate } otherwise { pastOrPresentMessage }
 
 @JvmName("localDateTimeIsInPastOrIsPresent")
-public fun Validatable<LocalDateTime?>.isInPastOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isInPastOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= currentLocalDateTime } otherwise { pastOrPresentMessage }
 
 @JvmName("zonedDateTimeIsInPastOrIsPresent")
-public fun Validatable<ZonedDateTime?>.isInPastOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<ZonedDateTime?, MetadataType>.isInPastOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= currentZonedDateTime } otherwise { pastOrPresentMessage }
 //endregion
 
@@ -77,19 +77,19 @@ public fun Validatable<ZonedDateTime?>.isInPastOrIsPresent(): Constraint =
 private const val futureMessage = "Must be in the future"
 
 @JvmName("instantFuture")
-public fun Validatable<Instant?>.isInFuture(): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isInFuture(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > currentInstant } otherwise { futureMessage }
 
 @JvmName("localDateFuture")
-public fun Validatable<LocalDate?>.isInFuture(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isInFuture(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > currentLocalDate } otherwise { futureMessage }
 
 @JvmName("localDateTimeFuture")
-public fun Validatable<LocalDateTime?>.isInFuture(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isInFuture(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > currentLocalDateTime } otherwise { futureMessage }
 
 @JvmName("zonedDateTimeFuture")
-public fun Validatable<ZonedDateTime?>.isInFuture(): Constraint =
+public fun <MetadataType> GenericValidatable<ZonedDateTime?, MetadataType>.isInFuture(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > currentZonedDateTime } otherwise { futureMessage }
 //endregion
 
@@ -97,83 +97,83 @@ public fun Validatable<ZonedDateTime?>.isInFuture(): Constraint =
 private const val futureOrPresentMessage = "Must be in the future or present"
 
 @JvmName("instantIsInFutureOrIsPresent")
-public fun Validatable<Instant?>.isInFutureOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isInFutureOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= currentInstant } otherwise { futureOrPresentMessage }
 
 @JvmName("localDateIsInFutureOrIsPresent")
-public fun Validatable<LocalDate?>.isInFutureOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isInFutureOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= currentLocalDate } otherwise { futureOrPresentMessage }
 
 @JvmName("localDateTimeIsInFutureOrIsPresent")
-public fun Validatable<LocalDateTime?>.isInFutureOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isInFutureOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= currentLocalDateTime } otherwise { futureOrPresentMessage }
 
 @JvmName("zonedDateTimeIsInFutureOrIsPresent")
-public fun Validatable<ZonedDateTime?>.isInFutureOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<ZonedDateTime?, MetadataType>.isInFutureOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= currentZonedDateTime } otherwise { futureOrPresentMessage }
 //endregion
 
 //region isBefore
-private infix fun Constraint.otherwiseBefore(other: Any) = otherwise { "Must be before \"$other\"" }
+private infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseBefore(other: Any) = otherwise { "Must be before \"$other\"" }
 
-public fun Validatable<Instant?>.isBefore(other: Instant): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isBefore(other: Instant): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < other } otherwiseBefore other
 
-public fun Validatable<LocalDate?>.isBefore(other: LocalDate): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isBefore(other: LocalDate): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < other } otherwiseBefore other
 
-public fun Validatable<LocalDateTime?>.isBefore(other: LocalDateTime): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isBefore(other: LocalDateTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < other } otherwiseBefore other
 
-public fun Validatable<ZonedDateTime?>.isBefore(other: ZonedDateTime): Constraint =
+public fun <MetadataType> GenericValidatable<ZonedDateTime?, MetadataType>.isBefore(other: ZonedDateTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < other } otherwiseBefore other
 //endregion
 
 //region isBeforeOrEqualTo
-private infix fun Constraint.otherwiseBeforeOrEqual(other: Any) = otherwise { "Must be before or equal to \"$other\"" }
+private infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseBeforeOrEqual(other: Any) = otherwise { "Must be before or equal to \"$other\"" }
 
-public fun Validatable<Instant?>.isBeforeOrEqualTo(other: Instant): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isBeforeOrEqualTo(other: Instant): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= other } otherwiseBeforeOrEqual other
 
-public fun Validatable<LocalDate?>.isBeforeOrEqualTo(other: LocalDate): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isBeforeOrEqualTo(other: LocalDate): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= other } otherwiseBeforeOrEqual other
 
-public fun Validatable<LocalDateTime?>.isBeforeOrEqualTo(other: LocalDateTime): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isBeforeOrEqualTo(other: LocalDateTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= other } otherwiseBeforeOrEqual other
 
-public fun Validatable<ZonedDateTime?>.isBeforeOrEqualTo(other: ZonedDateTime): Constraint =
+public fun <MetadataType> GenericValidatable<ZonedDateTime?, MetadataType>.isBeforeOrEqualTo(other: ZonedDateTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= other } otherwiseBeforeOrEqual other
 //endregion
 
 //region isAfter
-private infix fun Constraint.otherwiseAfter(other: Any) = otherwise { "Must be after \"$other\"" }
+private infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseAfter(other: Any) = otherwise { "Must be after \"$other\"" }
 
-public fun Validatable<Instant?>.isAfter(other: Instant): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isAfter(other: Instant): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > other } otherwiseAfter other
 
-public fun Validatable<LocalDate?>.isAfter(other: LocalDate): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isAfter(other: LocalDate): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > other } otherwiseAfter other
 
-public fun Validatable<LocalDateTime?>.isAfter(other: LocalDateTime): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isAfter(other: LocalDateTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > other } otherwiseAfter other
 
-public fun Validatable<ZonedDateTime?>.isAfter(other: ZonedDateTime): Constraint =
+public fun <MetadataType> GenericValidatable<ZonedDateTime?, MetadataType>.isAfter(other: ZonedDateTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > other } otherwiseAfter other
 //endregion
 
 //region isAfterOrEqualTo
-private infix fun Constraint.otherwiseAfterOrEqual(other: Any) = otherwise { "Must be after or equal to \"$other\"" }
+private infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseAfterOrEqual(other: Any) = otherwise { "Must be after or equal to \"$other\"" }
 
-public fun Validatable<Instant?>.isAfterOrEqualTo(other: Instant): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isAfterOrEqualTo(other: Instant): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= other } otherwiseAfterOrEqual other
 
-public fun Validatable<LocalDate?>.isAfterOrEqualTo(other: LocalDate): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isAfterOrEqualTo(other: LocalDate): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= other } otherwiseAfterOrEqual other
 
-public fun Validatable<LocalDateTime?>.isAfterOrEqualTo(other: LocalDateTime): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isAfterOrEqualTo(other: LocalDateTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= other } otherwiseAfterOrEqual other
 
-public fun Validatable<ZonedDateTime?>.isAfterOrEqualTo(other: ZonedDateTime): Constraint =
+public fun <MetadataType> GenericValidatable<ZonedDateTime?, MetadataType>.isAfterOrEqualTo(other: ZonedDateTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= other } otherwiseAfterOrEqual other
 //endregion
 
@@ -181,11 +181,11 @@ public fun Validatable<ZonedDateTime?>.isAfterOrEqualTo(other: ZonedDateTime): C
 private const val negativeMessage = "Must be negative"
 
 @JvmName("durationIsNegative")
-public fun Validatable<Duration?>.isNegative(): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isNegative(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isNegative && it != Duration.ZERO } otherwise { negativeMessage }
 
 @JvmName("periodIsNegative")
-public fun Validatable<Period?>.isNegative(): Constraint =
+public fun <MetadataType> GenericValidatable<Period?, MetadataType>.isNegative(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isNegative && it != Period.ZERO } otherwise { negativeMessage }
 //endregion
 
@@ -193,11 +193,11 @@ public fun Validatable<Period?>.isNegative(): Constraint =
 private const val negativeMessageOrZero = "Must be negative or equal to zero"
 
 @JvmName("durationIsNegativeOrZero")
-public fun Validatable<Duration?>.isNegativeOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isNegativeOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isNegative || it == Duration.ZERO } otherwise { negativeMessageOrZero }
 
 @JvmName("periodIsNegativeOrZero")
-public fun Validatable<Period?>.isNegativeOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Period?, MetadataType>.isNegativeOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it.isNegative || it == Period.ZERO } otherwise { negativeMessageOrZero }
 //endregion
 
@@ -205,11 +205,11 @@ public fun Validatable<Period?>.isNegativeOrZero(): Constraint =
 private const val positiveMessage = "Must be positive"
 
 @JvmName("durationIsPositive")
-public fun Validatable<Duration?>.isPositive(): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isPositive(): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.isNegative && it != Duration.ZERO } otherwise { positiveMessage }
 
 @JvmName("periodIsPositive")
-public fun Validatable<Period?>.isPositive(): Constraint =
+public fun <MetadataType> GenericValidatable<Period?, MetadataType>.isPositive(): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.isNegative && it != Period.ZERO } otherwise { positiveMessage }
 //endregion
 
@@ -217,39 +217,39 @@ public fun Validatable<Period?>.isPositive(): Constraint =
 private const val positiveMessageOrZero = "Must be positive or equal to zero"
 
 @JvmName("durationIsPositiveOrZero")
-public fun Validatable<Duration?>.isPositiveOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isPositiveOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.isNegative || it == Duration.ZERO } otherwise { positiveMessageOrZero }
 
 @JvmName("periodIsPositiveOrZero")
-public fun Validatable<Period?>.isPositiveOrZero(): Constraint =
+public fun <MetadataType> GenericValidatable<Period?, MetadataType>.isPositiveOrZero(): GenericConstraint<MetadataType> =
     constrainIfNotNull { !it.isNegative || it == Period.ZERO } otherwise { positiveMessageOrZero }
 //endregion
 
 //region isLowerThan
-public fun Validatable<Duration?>.isLowerThan(value: Duration): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isLowerThan(value: Duration): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < value } otherwise { "Must be lower than $value" }
 //endregion
 
 //region isLowerThanOrEqualTo
-public fun Validatable<Duration?>.isLowerThanOrEqualTo(value: Duration): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isLowerThanOrEqualTo(value: Duration): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= value } otherwise { "Must be lower than or equal to $value" }
 //endregion
 
 //region isGreaterThan
-public fun Validatable<Duration?>.isGreaterThan(value: Duration): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isGreaterThan(value: Duration): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > value } otherwise { "Must be greater than $value" }
 //endregion
 
 //region isGreaterThanOrEqualTo
-public fun Validatable<Duration?>.isGreaterThanOrEqualTo(value: Duration): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isGreaterThanOrEqualTo(value: Duration): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= value } otherwise { "Must be greater than or equal to $value" }
 //endregion
 
 //region isBetween
-public fun Validatable<Duration?>.isBetween(range: ClosedRange<Duration>): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isBetween(range: ClosedRange<Duration>): GenericConstraint<MetadataType> =
     constrainIfNotNull { it in range } otherwise { "Must be between ${range.start} and ${range.endInclusive} (inclusive)" }
 
-public fun Validatable<Duration?>.isBetween(range: OpenEndRange<Duration>): Constraint =
+public fun <MetadataType> GenericValidatable<Duration?, MetadataType>.isBetween(range: OpenEndRange<Duration>): GenericConstraint<MetadataType> =
     constrainIfNotNull { it in range } otherwise { "Must be between ${range.start} and ${range.endExclusive} (exclusive)" }
 //endregion
 

--- a/akkurate-kotlinx-datetime/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/KotlinxDatetime.kt
+++ b/akkurate-kotlinx-datetime/src/commonMain/kotlin/dev/nesk/akkurate/constraints/builders/KotlinxDatetime.kt
@@ -17,9 +17,10 @@
 
 package dev.nesk.akkurate.constraints.builders
 
-import dev.nesk.akkurate.constraints.Constraint
+import dev.nesk.akkurate.constraints.GenericConstraint
 import dev.nesk.akkurate.constraints.constrainIfNotNull
 import dev.nesk.akkurate.constraints.otherwise
+import dev.nesk.akkurate.validatables.GenericValidatable
 import dev.nesk.akkurate.validatables.Validatable
 import kotlinx.datetime.*
 import kotlin.jvm.JvmName
@@ -53,7 +54,7 @@ private const val pastMessage = "Must be in the past"
  * ```
  */
 @JvmName("instantIsInPast")
-public fun Validatable<Instant?>.isInPast(): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isInPast(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < currentInstant } otherwise { pastMessage }
 
 /**
@@ -72,7 +73,7 @@ public fun Validatable<Instant?>.isInPast(): Constraint =
  * ```
  */
 @JvmName("localDateIsInPast")
-public fun Validatable<LocalDate?>.isInPast(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isInPast(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < currentLocalDate } otherwise { pastMessage }
 
 /**
@@ -91,7 +92,7 @@ public fun Validatable<LocalDate?>.isInPast(): Constraint =
  * ```
  */
 @JvmName("localTimeIsInPast")
-public fun Validatable<LocalTime?>.isInPast(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalTime?, MetadataType>.isInPast(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < currentLocalTime } otherwise { pastMessage }
 
 /**
@@ -111,7 +112,7 @@ public fun Validatable<LocalTime?>.isInPast(): Constraint =
  * ```
  */
 @JvmName("localDateTimeIsInPast")
-public fun Validatable<LocalDateTime?>.isInPast(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isInPast(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < currentLocalDateTime } otherwise { pastMessage }
 //endregion
 
@@ -133,7 +134,7 @@ private const val pastOrPresentMessage = "Must be in the past or present"
  * ```
  */
 @JvmName("instantIsInPastOrIsPresent")
-public fun Validatable<Instant?>.isInPastOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isInPastOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= currentInstant } otherwise { pastOrPresentMessage }
 
 /**
@@ -152,7 +153,7 @@ public fun Validatable<Instant?>.isInPastOrIsPresent(): Constraint =
  * ```
  */
 @JvmName("localDateIsInPastOrIsPresent")
-public fun Validatable<LocalDate?>.isInPastOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isInPastOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= currentLocalDate } otherwise { pastOrPresentMessage }
 
 /**
@@ -171,7 +172,7 @@ public fun Validatable<LocalDate?>.isInPastOrIsPresent(): Constraint =
  * ```
  */
 @JvmName("localTimeIsInPastOrIsPresent")
-public fun Validatable<LocalTime?>.isInPastOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalTime?, MetadataType>.isInPastOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= currentLocalTime } otherwise { pastOrPresentMessage }
 
 /**
@@ -191,7 +192,7 @@ public fun Validatable<LocalTime?>.isInPastOrIsPresent(): Constraint =
  * ```
  */
 @JvmName("localDateTimeIsInPastOrIsPresent")
-public fun Validatable<LocalDateTime?>.isInPastOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isInPastOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= currentLocalDateTime } otherwise { pastOrPresentMessage }
 //endregion
 
@@ -213,7 +214,7 @@ private const val futureMessage = "Must be in the future"
  * ```
  */
 @JvmName("instantFuture")
-public fun Validatable<Instant?>.isInFuture(): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isInFuture(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > currentInstant } otherwise { futureMessage }
 
 /**
@@ -232,7 +233,7 @@ public fun Validatable<Instant?>.isInFuture(): Constraint =
  * ```
  */
 @JvmName("localDateFuture")
-public fun Validatable<LocalDate?>.isInFuture(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isInFuture(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > currentLocalDate } otherwise { futureMessage }
 
 /**
@@ -251,7 +252,7 @@ public fun Validatable<LocalDate?>.isInFuture(): Constraint =
  * ```
  */
 @JvmName("localTimeFuture")
-public fun Validatable<LocalTime?>.isInFuture(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalTime?, MetadataType>.isInFuture(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > currentLocalTime } otherwise { futureMessage }
 
 /**
@@ -271,7 +272,7 @@ public fun Validatable<LocalTime?>.isInFuture(): Constraint =
  * ```
  */
 @JvmName("localDateTimeFuture")
-public fun Validatable<LocalDateTime?>.isInFuture(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isInFuture(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > currentLocalDateTime } otherwise { futureMessage }
 //endregion
 
@@ -293,7 +294,7 @@ private const val futureOrPresentMessage = "Must be in the future or present"
  * ```
  */
 @JvmName("instantIsInFutureOrIsPresent")
-public fun Validatable<Instant?>.isInFutureOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isInFutureOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= currentInstant } otherwise { futureOrPresentMessage }
 
 /**
@@ -312,7 +313,7 @@ public fun Validatable<Instant?>.isInFutureOrIsPresent(): Constraint =
  * ```
  */
 @JvmName("localDateIsInFutureOrIsPresent")
-public fun Validatable<LocalDate?>.isInFutureOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isInFutureOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= currentLocalDate } otherwise { futureOrPresentMessage }
 
 /**
@@ -331,7 +332,7 @@ public fun Validatable<LocalDate?>.isInFutureOrIsPresent(): Constraint =
  * ```
  */
 @JvmName("localTimeIsInFutureOrIsPresent")
-public fun Validatable<LocalTime?>.isInFutureOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalTime?, MetadataType>.isInFutureOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= currentLocalTime } otherwise { futureOrPresentMessage }
 
 /**
@@ -351,12 +352,12 @@ public fun Validatable<LocalTime?>.isInFutureOrIsPresent(): Constraint =
  * ```
  */
 @JvmName("localDateTimeIsInFutureOrIsPresent")
-public fun Validatable<LocalDateTime?>.isInFutureOrIsPresent(): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isInFutureOrIsPresent(): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= currentLocalDateTime } otherwise { futureOrPresentMessage }
 //endregion
 
 //region isBefore
-private infix fun Constraint.otherwiseBefore(other: Any) = otherwise { "Must be before \"$other\"" }
+private infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseBefore(other: Any) = otherwise { "Must be before \"$other\"" }
 
 /**
  * The validatable [Instant] must be before [other] when this constraint is applied.
@@ -373,7 +374,7 @@ private infix fun Constraint.otherwiseBefore(other: Any) = otherwise { "Must be 
  * validate(now + 5.seconds) // Failure (message: Must be before "2024-08-31T12:30:15Z")
  * ```
  */
-public fun Validatable<Instant?>.isBefore(other: Instant): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isBefore(other: Instant): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < other } otherwiseBefore other
 
 /**
@@ -391,7 +392,7 @@ public fun Validatable<Instant?>.isBefore(other: Instant): Constraint =
  * validate(now.plus(2, DateTimeUnit.DAY)) // Failure (message: Must be before "2024-08-31")
  * ```
  */
-public fun Validatable<LocalDate?>.isBefore(other: LocalDate): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isBefore(other: LocalDate): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < other } otherwiseBefore other
 
 /**
@@ -409,7 +410,7 @@ public fun Validatable<LocalDate?>.isBefore(other: LocalDate): Constraint =
  * validate(LocalTime.fromSecondOfDay(now.toSecondOfDay() + 5)) // Failure (message: Must be before "12:30:15")
  * ```
  */
-public fun Validatable<LocalTime?>.isBefore(other: LocalTime): Constraint =
+public fun <MetadataType> GenericValidatable<LocalTime?, MetadataType>.isBefore(other: LocalTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < other } otherwiseBefore other
 
 /**
@@ -428,12 +429,12 @@ public fun Validatable<LocalTime?>.isBefore(other: LocalTime): Constraint =
  * validate((now.toInstant(timezone) + 5.seconds).toLocalDateTime(timezone)) // Failure (message: Must be before "2024-08-31T12:30:15")
  * ```
  */
-public fun Validatable<LocalDateTime?>.isBefore(other: LocalDateTime): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isBefore(other: LocalDateTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it < other } otherwiseBefore other
 //endregion
 
 //region isBeforeOrEqualTo
-private infix fun Constraint.otherwiseBeforeOrEqual(other: Any) = otherwise { "Must be before or equal to \"$other\"" }
+private infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseBeforeOrEqual(other: Any) = otherwise { "Must be before or equal to \"$other\"" }
 
 /**
  * The validatable [Instant] must be before or equal to [other] when this constraint is applied.
@@ -450,7 +451,7 @@ private infix fun Constraint.otherwiseBeforeOrEqual(other: Any) = otherwise { "M
  * validate(now + 5.seconds) // Failure (message: Must be before or equal to "2024-08-31T12:30:15Z")
  * ```
  */
-public fun Validatable<Instant?>.isBeforeOrEqualTo(other: Instant): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isBeforeOrEqualTo(other: Instant): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= other } otherwiseBeforeOrEqual other
 
 /**
@@ -468,7 +469,7 @@ public fun Validatable<Instant?>.isBeforeOrEqualTo(other: Instant): Constraint =
  * validate(now.plus(2, DateTimeUnit.DAY)) // Failure (message: Must be before or equal to "2024-08-31")
  * ```
  */
-public fun Validatable<LocalDate?>.isBeforeOrEqualTo(other: LocalDate): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isBeforeOrEqualTo(other: LocalDate): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= other } otherwiseBeforeOrEqual other
 
 /**
@@ -486,7 +487,7 @@ public fun Validatable<LocalDate?>.isBeforeOrEqualTo(other: LocalDate): Constrai
  * validate(LocalTime.fromSecondOfDay(now.toSecondOfDay() + 5)) // Failure (message: Must be before or equal to "12:30:15")
  * ```
  */
-public fun Validatable<LocalTime?>.isBeforeOrEqualTo(other: LocalTime): Constraint =
+public fun <MetadataType> GenericValidatable<LocalTime?, MetadataType>.isBeforeOrEqualTo(other: LocalTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= other } otherwiseBeforeOrEqual other
 
 /**
@@ -505,12 +506,12 @@ public fun Validatable<LocalTime?>.isBeforeOrEqualTo(other: LocalTime): Constrai
  * validate((now.toInstant(timezone) + 5.seconds).toLocalDateTime(timezone)) // Failure (message: Must be before or equal to "2024-08-31T12:30:15")
  * ```
  */
-public fun Validatable<LocalDateTime?>.isBeforeOrEqualTo(other: LocalDateTime): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isBeforeOrEqualTo(other: LocalDateTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it <= other } otherwiseBeforeOrEqual other
 //endregion
 
 //region isAfter
-private infix fun Constraint.otherwiseAfter(other: Any) = otherwise { "Must be after \"$other\"" }
+private infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseAfter(other: Any) = otherwise { "Must be after \"$other\"" }
 
 /**
  * The validatable [Instant] must be after [other] when this constraint is applied.
@@ -527,7 +528,7 @@ private infix fun Constraint.otherwiseAfter(other: Any) = otherwise { "Must be a
  * validate(now - 5.seconds) // Failure (message: Must be after "2024-08-31T12:30:15Z")
  * ```
  */
-public fun Validatable<Instant?>.isAfter(other: Instant): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isAfter(other: Instant): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > other } otherwiseAfter other
 
 /**
@@ -545,7 +546,7 @@ public fun Validatable<Instant?>.isAfter(other: Instant): Constraint =
  * validate(now.minus(2, DateTimeUnit.DAY)) // Failure (message: Must be after "2024-08-31")
  * ```
  */
-public fun Validatable<LocalDate?>.isAfter(other: LocalDate): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isAfter(other: LocalDate): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > other } otherwiseAfter other
 
 /**
@@ -563,7 +564,7 @@ public fun Validatable<LocalDate?>.isAfter(other: LocalDate): Constraint =
  * validate(LocalTime.fromSecondOfDay(now.toSecondOfDay() - 5)) // Failure (message: Must be after "12:30:15")
  * ```
  */
-public fun Validatable<LocalTime?>.isAfter(other: LocalTime): Constraint =
+public fun <MetadataType> GenericValidatable<LocalTime?, MetadataType>.isAfter(other: LocalTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > other } otherwiseAfter other
 
 /**
@@ -582,12 +583,12 @@ public fun Validatable<LocalTime?>.isAfter(other: LocalTime): Constraint =
  * validate((now.toInstant(timezone) - 5.seconds).toLocalDateTime(timezone)) // Failure (message: Must be after "2024-08-31T12:30:15")
  * ```
  */
-public fun Validatable<LocalDateTime?>.isAfter(other: LocalDateTime): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isAfter(other: LocalDateTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it > other } otherwiseAfter other
 //endregion
 
 //region isAfterOrEqualTo
-private infix fun Constraint.otherwiseAfterOrEqual(other: Any) = otherwise { "Must be after or equal to \"$other\"" }
+private infix fun <MetadataType> GenericConstraint<MetadataType>.otherwiseAfterOrEqual(other: Any) = otherwise { "Must be after or equal to \"$other\"" }
 
 /**
  * The validatable [Instant] must be after or equal to [other] when this constraint is applied.
@@ -604,7 +605,7 @@ private infix fun Constraint.otherwiseAfterOrEqual(other: Any) = otherwise { "Mu
  * validate(now - 5.seconds) // Failure (message: Must be after or equal to "2024-08-31T12:30:15Z")
  * ```
  */
-public fun Validatable<Instant?>.isAfterOrEqualTo(other: Instant): Constraint =
+public fun <MetadataType> GenericValidatable<Instant?, MetadataType>.isAfterOrEqualTo(other: Instant): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= other } otherwiseAfterOrEqual other
 
 /**
@@ -622,7 +623,7 @@ public fun Validatable<Instant?>.isAfterOrEqualTo(other: Instant): Constraint =
  * validate(now.minus(2, DateTimeUnit.DAY)) // Failure (message: Must be after or equal to "2024-08-31")
  * ```
  */
-public fun Validatable<LocalDate?>.isAfterOrEqualTo(other: LocalDate): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDate?, MetadataType>.isAfterOrEqualTo(other: LocalDate): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= other } otherwiseAfterOrEqual other
 
 /**
@@ -640,7 +641,7 @@ public fun Validatable<LocalDate?>.isAfterOrEqualTo(other: LocalDate): Constrain
  * validate(LocalTime.fromSecondOfDay(now.toSecondOfDay() - 5)) // Failure (message: Must be after or equal to "12:30:15")
  * ```
  */
-public fun Validatable<LocalTime?>.isAfterOrEqualTo(other: LocalTime): Constraint =
+public fun <MetadataType> GenericValidatable<LocalTime?, MetadataType>.isAfterOrEqualTo(other: LocalTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= other } otherwiseAfterOrEqual other
 
 /**
@@ -659,6 +660,6 @@ public fun Validatable<LocalTime?>.isAfterOrEqualTo(other: LocalTime): Constrain
  * validate((now.toInstant(timezone) - 5.seconds).toLocalDateTime(timezone)) // Failure (message: Must be after or equal to "2024-08-31T12:30:15")
  * ```
  */
-public fun Validatable<LocalDateTime?>.isAfterOrEqualTo(other: LocalDateTime): Constraint =
+public fun <MetadataType> GenericValidatable<LocalDateTime?, MetadataType>.isAfterOrEqualTo(other: LocalDateTime): GenericConstraint<MetadataType> =
     constrainIfNotNull { it >= other } otherwiseAfterOrEqual other
 //endregion

--- a/akkurate-ktor-client/src/commonMain/kotlin/dev/nesk/akkurate/ktor/client/AkkurateConfig.kt
+++ b/akkurate-ktor-client/src/commonMain/kotlin/dev/nesk/akkurate/ktor/client/AkkurateConfig.kt
@@ -36,8 +36,8 @@ public class AkkurateConfig internal constructor() {
      * Registers a new [validator], which will be executed for each deserialized response body.
      * The [contextProvider] is called on each execution, then its result is feed to the validator.
      */
-    public inline fun <ContextType, reified ValueType> registerValidator(
-        validator: Validator.Runner.WithContext<ContextType, ValueType>,
+    public inline fun <ContextType, reified ValueType, MetadataType> registerValidator(
+        validator: Validator.Runner.WithContext<ContextType, ValueType, MetadataType>,
         noinline contextProvider: suspend () -> ContextType,
     ) {
         registerValidator(ClientValidator.Runner.WithContext(ValueType::class, validator, contextProvider))
@@ -46,7 +46,7 @@ public class AkkurateConfig internal constructor() {
     /**
      * Registers a new [validator], which will be executed for each deserialized response body.
      */
-    public inline fun <reified ValueType> registerValidator(validator: Validator.Runner<ValueType>) {
+    public inline fun <reified ValueType, MetadataType> registerValidator(validator: Validator.Runner<ValueType, MetadataType>) {
         registerValidator(ClientValidator.Runner(ValueType::class, validator))
     }
 
@@ -54,8 +54,8 @@ public class AkkurateConfig internal constructor() {
      * Registers a new [validator], which will be executed for each deserialized response body.
      * The [contextProvider] is called on each execution, then its result is feed to the validator.
      */
-    public inline fun <ContextType, reified ValueType> registerValidator(
-        validator: Validator.SuspendableRunner.WithContext<ContextType, ValueType>,
+    public inline fun <ContextType, reified ValueType, MetadataType> registerValidator(
+        validator: Validator.SuspendableRunner.WithContext<ContextType, ValueType, MetadataType>,
         noinline contextProvider: suspend () -> ContextType,
     ) {
         registerValidator(ClientValidator.SuspendableRunner.WithContext(ValueType::class, validator, contextProvider))
@@ -64,7 +64,7 @@ public class AkkurateConfig internal constructor() {
     /**
      * Registers a new [validator], which will be executed for each deserialized response body.
      */
-    public inline fun <reified ValueType> registerValidator(validator: Validator.SuspendableRunner<ValueType>) {
+    public inline fun <reified ValueType, MetadataType> registerValidator(validator: Validator.SuspendableRunner<ValueType, MetadataType>) {
         registerValidator(ClientValidator.SuspendableRunner(ValueType::class, validator))
     }
 }

--- a/akkurate-ktor-client/src/commonMain/kotlin/dev/nesk/akkurate/ktor/client/ClientValidator.kt
+++ b/akkurate-ktor-client/src/commonMain/kotlin/dev/nesk/akkurate/ktor/client/ClientValidator.kt
@@ -35,9 +35,9 @@ public interface ClientValidator {
     /**
      * A validator for [Validator.Runner] instances.
      */
-    public class Runner<ValueType>(
+    public class Runner<ValueType, MetadataType>(
         private val valueType: KClass<*>,
-        private val validator: Validator.Runner<ValueType>,
+        private val validator: Validator.Runner<ValueType, MetadataType>,
     ) : ClientValidator {
         override suspend fun validate(value: Any?) {
             if (!valueType.isInstance(value)) return
@@ -49,9 +49,9 @@ public interface ClientValidator {
         /**
          * A validator for [Validator.Runner.WithContext] instances.
          */
-        public class WithContext<ContextType, ValueType>(
+        public class WithContext<ContextType, ValueType, MetadataType>(
             private val valueType: KClass<*>,
-            private val validator: Validator.Runner.WithContext<ContextType, ValueType>,
+            private val validator: Validator.Runner.WithContext<ContextType, ValueType, MetadataType>,
             private val contextProvider: suspend () -> ContextType,
         ) : ClientValidator {
             override suspend fun validate(value: Any?) {
@@ -66,9 +66,9 @@ public interface ClientValidator {
     /**
      * A validator for [Validator.SuspendableRunner] instances.
      */
-    public class SuspendableRunner<ValueType>(
+    public class SuspendableRunner<ValueType, MetadataType>(
         private val valueType: KClass<*>,
-        private val validator: Validator.SuspendableRunner<ValueType>,
+        private val validator: Validator.SuspendableRunner<ValueType, MetadataType>,
     ) : ClientValidator {
         override suspend fun validate(value: Any?) {
             if (!valueType.isInstance(value)) return
@@ -80,9 +80,9 @@ public interface ClientValidator {
         /**
          * A validator for [Validator.SuspendableRunner.WithContext] instances.
          */
-        public class WithContext<ContextType, ValueType>(
+        public class WithContext<ContextType, ValueType, MetadataType>(
             private val valueType: KClass<*>,
-            private val validator: Validator.SuspendableRunner.WithContext<ContextType, ValueType>,
+            private val validator: Validator.SuspendableRunner.WithContext<ContextType, ValueType, MetadataType>,
             private val contextProvider: suspend () -> ContextType,
         ) : ClientValidator {
             override suspend fun validate(value: Any?) {

--- a/akkurate-ktor-server/src/commonMain/kotlin/dev/nesk/akkurate/ktor/server/AkkurateConfig.kt
+++ b/akkurate-ktor-server/src/commonMain/kotlin/dev/nesk/akkurate/ktor/server/AkkurateConfig.kt
@@ -18,6 +18,7 @@
 package dev.nesk.akkurate.ktor.server
 
 import dev.nesk.akkurate.constraints.ConstraintViolationSet
+import dev.nesk.akkurate.constraints.GenericConstraintViolationSet
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*

--- a/akkurate-ktor-server/src/commonMain/kotlin/dev/nesk/akkurate/ktor/server/RegisterValidator.kt
+++ b/akkurate-ktor-server/src/commonMain/kotlin/dev/nesk/akkurate/ktor/server/RegisterValidator.kt
@@ -18,6 +18,7 @@
 package dev.nesk.akkurate.ktor.server
 
 import dev.nesk.akkurate.Validator
+import dev.nesk.akkurate.validatables.DefaultMetadataType
 import io.ktor.server.plugins.requestvalidation.*
 import io.ktor.server.request.*
 
@@ -26,7 +27,7 @@ import io.ktor.server.request.*
  * The [contextProvider] is called on each execution, then its result is feed to the validator.
  */
 public inline fun <ContextType, reified ValueType : Any> RequestValidationConfig.registerValidator(
-    validator: Validator.Runner.WithContext<ContextType, ValueType>,
+    validator: Validator.Runner.WithContext<ContextType, ValueType, DefaultMetadataType>,
     noinline contextProvider: suspend () -> ContextType,
 ) {
     validate<ValueType> {
@@ -38,7 +39,7 @@ public inline fun <ContextType, reified ValueType : Any> RequestValidationConfig
 /**
  * Registers a new [validator], which will be executed for each [received][receive] request body.
  */
-public inline fun <reified ValueType : Any> RequestValidationConfig.registerValidator(validator: Validator.Runner<ValueType>) {
+public inline fun <reified ValueType : Any> RequestValidationConfig.registerValidator(validator: Validator.Runner<ValueType, DefaultMetadataType>) {
     validate<ValueType> {
         validator(it).orThrow()
         ValidationResult.Valid
@@ -50,7 +51,7 @@ public inline fun <reified ValueType : Any> RequestValidationConfig.registerVali
  * The [contextProvider] is called on each execution, then its result is feed to the validator.
  */
 public inline fun <ContextType, reified ValueType : Any> RequestValidationConfig.registerValidator(
-    validator: Validator.SuspendableRunner.WithContext<ContextType, ValueType>,
+    validator: Validator.SuspendableRunner.WithContext<ContextType, ValueType, DefaultMetadataType>,
     noinline contextProvider: suspend () -> ContextType,
 ) {
     validate<ValueType> {
@@ -62,7 +63,7 @@ public inline fun <ContextType, reified ValueType : Any> RequestValidationConfig
 /**
  * Registers a new [validator], which will be executed for each [received][receive] request body.
  */
-public inline fun <reified ValueType : Any> RequestValidationConfig.registerValidator(validator: Validator.SuspendableRunner<ValueType>) {
+public inline fun <reified ValueType : Any> RequestValidationConfig.registerValidator(validator: Validator.SuspendableRunner<ValueType, DefaultMetadataType>) {
     validate<ValueType> {
         validator(it).orThrow()
         ValidationResult.Valid

--- a/akkurate-ktor-server/src/commonTest/kotlin/dev/nesk/akkurate/ktor/server/AkkurateTest.kt
+++ b/akkurate-ktor-server/src/commonTest/kotlin/dev/nesk/akkurate/ktor/server/AkkurateTest.kt
@@ -84,7 +84,7 @@ class AkkurateTest {
         val response = client.sendBoolean(false)
 
         assertEquals(
-            "ConstraintViolationSet(messages=[ConstraintViolation(message='Must be true', path=[])])",
+            "ConstraintViolationSet(messages=[ConstraintViolation(message='Must be true', path=[], metadata={})])",
             response.bodyAsText(),
             "The body contains a string representation of ConstraintViolationSet."
         )


### PR DESCRIPTION
Try to solve #34 with a generic metadata property in the `Constraint` class, while keeping the backward compatibility as much as possible by defining type aliases for `Contraint`/`Validatable`. But haven't made the type alias for `Runner`'s subclasses yet.

On the ktor integration, it still uses the default metadata type, as the Exception class can not be generic. It may need some more work to make it accept different types for metadata if we want.

@nesk Do you think it's a good idea to add the metadata support like this? Or there's something else in your mind?
If you think it's the right way to do, I can carry on and refine the PR further.